### PR TITLE
[Feat] Global Exception Handler 및 공통 응답 규격 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,6 @@ out/
 
 ### env ###
 .env
+
+### application ##
+application.yaml

--- a/build.gradle
+++ b/build.gradle
@@ -25,18 +25,40 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
-	compileOnly 'org.projectlombok:lombok'
-	annotationProcessor 'org.projectlombok:lombok'
+
+	// test
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	// lombok
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
 
 	// DB
 	runtimeOnly 'org.postgresql:postgresql'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-
 	implementation 'org.hibernate.orm:hibernate-spatial'
 
+	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+
+	// security
+	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	// validation
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+	// querydsl
+	implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
+	annotationProcessor "com.querydsl:querydsl-apt:${dependencyManagement.importedProperties['querydsl.version']}:jakarta"
+	annotationProcessor "jakarta.annotation:jakarta.annotation-api"
+	annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+	// swagger
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.7.0'
+
+	// Mockito
+	testImplementation 'org.mockito:mockito-junit-jupiter:5.2.0'
 
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -69,3 +69,4 @@ jar {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,16 @@
+services:
+  postgres:
+    image: postgis/postgis:16-3.4-alpine
+    container_name: runsync-postgres
+    ports:
+      - "5432:5432"
+    environment:
+      POSTGRES_DB: runsync
+      POSTGRES_USER: runsync
+      POSTGRES_PASSWORD: 1234
+
+  redis:
+    image: redis:alpine
+    container_name: runsync-redis
+    ports:
+      - "6379:6379"

--- a/src/main/java/com/_s3k/runsync/global/common/dto/CommonResponse.java
+++ b/src/main/java/com/_s3k/runsync/global/common/dto/CommonResponse.java
@@ -20,6 +20,7 @@ public class CommonResponse<T> {
     public CommonResponse(ResultCode resultCode) {
         this.statusCode = resultCode.getCode();
         this.message = resultCode.getMessage();
+        this.data = null;
     }
 
     // Validation 오류 메시지용 생성자

--- a/src/main/java/com/_s3k/runsync/global/common/dto/CommonResponse.java
+++ b/src/main/java/com/_s3k/runsync/global/common/dto/CommonResponse.java
@@ -1,0 +1,43 @@
+package com._s3k.runsync.global.common.dto;
+
+import com._s3k.runsync.global.exception.GlobalErrorCode;
+import com._s3k.runsync.global.exception.ResultCode;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class CommonResponse<T> {
+    @Schema(description = "http Status code")
+    private final Integer statusCode;
+    @Schema(description = "http status 메시지")
+    private final String message;
+    @Schema(description = "데이터")
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    private T data;
+
+    // 오류 등 데이터 없는 경우 사용
+    public CommonResponse(ResultCode resultCode) {
+        this.statusCode = resultCode.getCode();
+        this.message = resultCode.getMessage();
+    }
+
+    // Validation 오류 메시지용 생성자
+    public CommonResponse(Integer statusCode, String message) {
+        this.statusCode = statusCode;
+        this.message = message;
+        this.data = null;
+    }
+
+    // 성공 시 일반적인 생성자
+    public CommonResponse(ResultCode resultCode, T data) {
+        this.statusCode = resultCode.getCode();
+        this.message = resultCode.getMessage();
+        this.data = data;
+    }
+
+    // 이거 호출로 성공 생성자 자동 호출, 데이터 담아서 반환됨
+    public static <T> CommonResponse<T> success(T data) {
+        return new CommonResponse<>(GlobalErrorCode.SUCCESS, data);
+    }
+}

--- a/src/main/java/com/_s3k/runsync/global/config/JpaAuditingConfig.java
+++ b/src/main/java/com/_s3k/runsync/global/config/JpaAuditingConfig.java
@@ -1,0 +1,9 @@
+package com._s3k.runsync.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaAuditingConfig {
+}

--- a/src/main/java/com/_s3k/runsync/global/config/QueryDslConfig.java
+++ b/src/main/java/com/_s3k/runsync/global/config/QueryDslConfig.java
@@ -1,0 +1,19 @@
+package com._s3k.runsync.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QueryDslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/_s3k/runsync/global/config/SwaggerConfig.java
+++ b/src/main/java/com/_s3k/runsync/global/config/SwaggerConfig.java
@@ -1,0 +1,39 @@
+package com._s3k.runsync.global.config;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@OpenAPIDefinition(
+    servers = {
+        @Server(url = "http://localhost:8080", description = "Local Host URL")
+    }
+)
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public OpenAPI openAPI() {
+        return new OpenAPI()
+            .components(new Components()
+                .addSecuritySchemes("Authorization", new SecurityScheme()
+                    .type(SecurityScheme.Type.HTTP)
+                    .scheme("bearer")
+                    .in(SecurityScheme.In.HEADER)
+                    .bearerFormat("JWT")
+                )
+            )
+            .addSecurityItem(new SecurityRequirement().addList("Authorization"))
+            .info(new Info()
+                .title("RunSync API")
+                .description("RunSync API 명세서")
+                .version("1.0.0")
+            );
+    }
+}

--- a/src/main/java/com/_s3k/runsync/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/global/exception/GlobalErrorCode.java
@@ -8,7 +8,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum GlobalErrorCode implements ResultCode {
     SUCCESS(HttpStatus.OK, 0, "정상 처리 되었습니다."),
-    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, 9001, "요청 값이 유효하지 않습니다.");
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, 9001, "요청 값이 유효하지 않습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, 9000, "서버 내부 오류가 발생했습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/global/exception/GlobalErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/global/exception/GlobalErrorCode.java
@@ -1,0 +1,16 @@
+package com._s3k.runsync.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ResultCode {
+    SUCCESS(HttpStatus.OK, 0, "정상 처리 되었습니다."),
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, 9001, "요청 값이 유효하지 않습니다.");
+
+    private final HttpStatus status;
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/_s3k/runsync/global/exception/GlobalException.java
+++ b/src/main/java/com/_s3k/runsync/global/exception/GlobalException.java
@@ -1,0 +1,10 @@
+package com._s3k.runsync.global.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class GlobalException extends RuntimeException {
+    private final ResultCode resultCode;
+}

--- a/src/main/java/com/_s3k/runsync/global/exception/GlobalException.java
+++ b/src/main/java/com/_s3k/runsync/global/exception/GlobalException.java
@@ -4,7 +4,11 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
 public class GlobalException extends RuntimeException {
     private final ResultCode resultCode;
+
+    public GlobalException(ResultCode resultCode) {
+        super(resultCode.getMessage());
+        this.resultCode = resultCode;
+    }
 }

--- a/src/main/java/com/_s3k/runsync/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/_s3k/runsync/global/exception/GlobalExceptionHandler.java
@@ -25,6 +25,14 @@ public class GlobalExceptionHandler {
             .body(new CommonResponse<>(e.getResultCode()));
     }
 
+    // 처리되지 않은 일반 예외 처리
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<CommonResponse<Void>> handleUnexpectedException(Exception e) {
+        log.error("Unexpected exception occurred", e);
+        return ResponseEntity.status(GlobalErrorCode.INTERNAL_SERVER_ERROR.getStatus())
+            .body(new CommonResponse<>(GlobalErrorCode.INTERNAL_SERVER_ERROR));
+    }
+
     // Validation 실패 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<CommonResponse<Void>> handleValidation(MethodArgumentNotValidException e) {

--- a/src/main/java/com/_s3k/runsync/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/_s3k/runsync/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,44 @@
+package com._s3k.runsync.global.exception;
+
+import com._s3k.runsync.global.common.dto.CommonResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    // GlobalException 발생 시 반환 형태
+    @ExceptionHandler(GlobalException.class)
+    public ResponseEntity<CommonResponse<Void>> handleException(GlobalException e) {
+        log.error("GlobalException occurred: code={}, status={}, message={}",
+            e.getResultCode().getCode(),
+            e.getResultCode().getStatus(),
+            e.getResultCode().getMessage(),
+            e
+        );
+        return ResponseEntity.status(e.getResultCode().getStatus())
+            .body(new CommonResponse<>(e.getResultCode()));
+    }
+
+    // Validation 실패 처리
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<CommonResponse<Void>> handleValidation(MethodArgumentNotValidException e) {
+        String message = e.getBindingResult()
+            .getFieldErrors()
+            .stream()
+            .findFirst()
+            .map(FieldError::getDefaultMessage)
+            .orElse(GlobalErrorCode.VALIDATION_ERROR.getMessage());
+
+        log.warn("Validation failed: {}", message);
+
+        return ResponseEntity
+            .status(GlobalErrorCode.VALIDATION_ERROR.getStatus())
+            .body(new CommonResponse<>(GlobalErrorCode.VALIDATION_ERROR.getCode(), message));
+    }
+}

--- a/src/main/java/com/_s3k/runsync/global/exception/ResultCode.java
+++ b/src/main/java/com/_s3k/runsync/global/exception/ResultCode.java
@@ -1,0 +1,9 @@
+package com._s3k.runsync.global.exception;
+
+import org.springframework.http.HttpStatus;
+
+public interface ResultCode {
+    HttpStatus getStatus();
+    int getCode();
+    String getMessage();
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #3 

## 📝작업 내용
- ResultCode 인터페이스 정의
- GlobalException 커스텀 예외 클래스 추가
- GlobalErrorCode 공통 에러코드 enum 추가
- GlobalExceptionHandler 전역 예외 핸들러 추가
- CommonResponse 공통 응답 DTO 추가
- JpaAuditingConfig JPA Auditing 활성화
- QueryDslConfig JPAQueryFactory 빈 등록
- SwaggerConfig Swagger 설정 추가

## 📷스크린샷 (선택)

## 💬리뷰 요구사항(선택)