### PR TITLE
[Feat] 러닝 세션 시작 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
@@ -1,0 +1,31 @@
+package com._s3k.runsync.domain.run.controller;
+
+import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
+import com._s3k.runsync.domain.run.dto.response.RunSessionStartRes;
+import com._s3k.runsync.domain.run.service.RunSessionService;
+import com._s3k.runsync.global.common.dto.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/run-sessions")
+@RequiredArgsConstructor
+public class RunSessionController {
+
+    private final RunSessionService runSessionService;
+
+    @PostMapping
+    @Operation(summary = "러닝 시작", description = "러닝 세션을 생성합니다. 로그인 필요")
+    public CommonResponse<RunSessionStartRes> createRunSession(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody RunSessionStartReq request
+    ) {
+        return CommonResponse.success(runSessionService.createRunSession(userId, request));
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunSessionStartReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunSessionStartReq.java
@@ -2,17 +2,19 @@ package com._s3k.runsync.domain.run.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PastOrPresent;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 
 @Getter
-@Setter
+@NoArgsConstructor
 @Schema(description = "러닝 세션 시작 요청")
 public class RunSessionStartReq {
 
     @NotNull
+    @PastOrPresent
     @Schema(description = "러닝 시작 시간", example = "2026-04-10T22:11:00")
     private LocalDateTime startTime;
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunSessionStartReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunSessionStartReq.java
@@ -1,0 +1,18 @@
+package com._s3k.runsync.domain.run.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@Schema(description = "러닝 세션 시작 요청")
+public class RunSessionStartReq {
+
+    @NotNull
+    @Schema(description = "러닝 시작 시간", example = "2026-04-10T22:11:00")
+    private LocalDateTime startTime;
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunSessionStartRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunSessionStartRes.java
@@ -1,0 +1,29 @@
+package com._s3k.runsync.domain.run.dto.response;
+
+import com._s3k.runsync.entity.RunningSession;
+import com._s3k.runsync.entity.enums.RunningSessionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "러닝 세션 시작 응답")
+public class RunSessionStartRes {
+
+    @Schema(description = "세션 ID", example = "1")
+    private Long sessionId;
+
+    @Schema(description = "세션 상태", example = "ACTIVE")
+    private RunningSessionStatus status;
+
+    private RunSessionStartRes(Long sessionId, RunningSessionStatus status) {
+        this.sessionId = sessionId;
+        this.status = status;
+    }
+
+    public static RunSessionStartRes of(RunningSession session) {
+        return new RunSessionStartRes(
+                session.getId(),
+                session.getStatus()
+        );
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/exception/RunSessionErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/exception/RunSessionErrorCode.java
@@ -1,0 +1,17 @@
+package com._s3k.runsync.domain.run.exception;
+
+import com._s3k.runsync.global.exception.ResultCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RunSessionErrorCode implements ResultCode {
+
+    ACTIVE_SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, 3001, "이미 진행 중인 러닝 세션이 있습니다.");
+
+    private final HttpStatus status;
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/repository/RunningSessionRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/RunningSessionRepository.java
@@ -1,0 +1,10 @@
+package com._s3k.runsync.domain.run.repository;
+
+import com._s3k.runsync.entity.RunningSession;
+import com._s3k.runsync.entity.enums.RunningSessionStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RunningSessionRepository extends JpaRepository<RunningSession, Long> {
+
+    boolean existsByUserIdAndStatus(Long userId, RunningSessionStatus status);
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
@@ -1,0 +1,38 @@
+package com._s3k.runsync.domain.run.service;
+
+import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
+import com._s3k.runsync.domain.run.dto.response.RunSessionStartRes;
+import com._s3k.runsync.domain.run.exception.RunSessionErrorCode;
+import com._s3k.runsync.domain.run.repository.RunningSessionRepository;
+import com._s3k.runsync.domain.users.exception.UserErrorCode;
+import com._s3k.runsync.domain.users.repository.UserRepository;
+import com._s3k.runsync.entity.RunningSession;
+import com._s3k.runsync.entity.User;
+import com._s3k.runsync.entity.enums.RunningSessionStatus;
+import com._s3k.runsync.global.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RunSessionService {
+
+    private final UserRepository userRepository;
+    private final RunningSessionRepository runningSessionRepository;
+
+    @Transactional
+    public RunSessionStartRes createRunSession(Long userId, RunSessionStartReq request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
+
+        if (runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)) {
+            throw new GlobalException(RunSessionErrorCode.ACTIVE_SESSION_ALREADY_EXISTS);
+        }
+
+        RunningSession session = RunningSession.of(user, request.getStartTime());
+        runningSessionRepository.save(session);
+
+        return RunSessionStartRes.of(session);
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
@@ -11,6 +11,7 @@ import com._s3k.runsync.entity.User;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
 import com._s3k.runsync.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,13 +27,18 @@ public class RunSessionService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
 
+        // 일반적인 경우 서비스 레벨에서 차단
         if (runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)) {
             throw new GlobalException(RunSessionErrorCode.ACTIVE_SESSION_ALREADY_EXISTS);
         }
 
-        RunningSession session = RunningSession.of(user, request.getStartTime());
-        runningSessionRepository.save(session);
-
-        return RunSessionStartRes.of(session);
+        try {
+            RunningSession session = RunningSession.of(user, request.getStartTime());
+            runningSessionRepository.save(session);
+            return RunSessionStartRes.of(session);
+        } catch (DataIntegrityViolationException e) {
+            // 동시 요청 시 DB 유니크 인덱스(idx_user_active_session)가 잡아주는 케이스
+            throw new GlobalException(RunSessionErrorCode.ACTIVE_SESSION_ALREADY_EXISTS);
+        }
     }
 }

--- a/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
@@ -1,0 +1,103 @@
+package com._s3k.runsync.domain.run.service;
+
+import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
+import com._s3k.runsync.domain.run.dto.response.RunSessionStartRes;
+import com._s3k.runsync.domain.run.exception.RunSessionErrorCode;
+import com._s3k.runsync.domain.run.repository.RunningSessionRepository;
+import com._s3k.runsync.domain.users.exception.UserErrorCode;
+import com._s3k.runsync.domain.users.repository.UserRepository;
+import com._s3k.runsync.entity.RunningSession;
+import com._s3k.runsync.entity.User;
+import com._s3k.runsync.entity.enums.Provider;
+import com._s3k.runsync.entity.enums.RunningSessionStatus;
+import com._s3k.runsync.global.exception.GlobalException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class RunSessionServiceTest {
+
+    @InjectMocks
+    private RunSessionService runSessionService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RunningSessionRepository runningSessionRepository;
+
+    @Test
+    @DisplayName("러닝 세션 생성 성공")
+    void createRunSession_success() {
+        // given
+        Long userId = 1L;
+        RunSessionStartReq request = new RunSessionStartReq();
+        request.setStartTime(LocalDateTime.now());
+
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(false);
+        given(runningSessionRepository.save(any(RunningSession.class))).willAnswer(i -> i.getArgument(0));
+
+        // when
+        RunSessionStartRes result = runSessionService.createRunSession(userId, request);
+
+        // then
+        assertThat(result.getStatus()).isEqualTo(RunningSessionStatus.ACTIVE);
+        verify(runningSessionRepository).save(any(RunningSession.class));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저로 러닝 세션 생성 시 예외 발생")
+    void createRunSession_userNotFound() {
+        // given
+        Long userId = 1L;
+        RunSessionStartReq request = new RunSessionStartReq();
+        request.setStartTime(LocalDateTime.now());
+
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.createRunSession(userId, request))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+
+        verify(runningSessionRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("이미 진행 중인 세션이 있을 때 예외 발생")
+    void createRunSession_activeSessionAlreadyExists() {
+        // given
+        Long userId = 1L;
+        RunSessionStartReq request = new RunSessionStartReq();
+        request.setStartTime(LocalDateTime.now());
+
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.createRunSession(userId, request))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunSessionErrorCode.ACTIVE_SESSION_ALREADY_EXISTS));
+
+        verify(runningSessionRepository, never()).save(any());
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6 

## 📝작업 내용

러닝 세션 시작 API (POST /api/run-sessions) 구현
- RunSessionStartReq / RunSessionStartRes DTO 추가
- RunningSessionRepository 생성 및 ACTIVE 세션 존재 여부 조회 메서드 추가
- RunSessionService 생성 (유저 존재 여부, 중복 세션 검증 포함)
- RunSessionController 생성
- RunSessionErrorCode 추가 (3001: 이미 진행 중인 세션 존재)
-  RunSessionServiceTest 단위 테스트 작성

## 📷스크린샷

<img width="1402" height="489" alt="image" src="https://github.com/user-attachments/assets/0e0ea428-7811-4b77-befc-a78bdd183b5c" />