### PR TITLE
[Feat] 러닝 중 위치 저장 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
@@ -1,5 +1,6 @@
 package com._s3k.runsync.domain.run.controller;
 
+import com._s3k.runsync.domain.run.dto.request.LocationUpdateReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
 import com._s3k.runsync.domain.run.dto.response.RunSessionStartRes;
 import com._s3k.runsync.domain.run.service.RunSessionService;
@@ -8,10 +9,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/run-sessions")
@@ -27,5 +25,16 @@ public class RunSessionController {
             @Valid @RequestBody RunSessionStartReq request
     ) {
         return CommonResponse.success(runSessionService.createRunSession(userId, request));
+    }
+
+    @PatchMapping("/{sessionId}/location")
+    @Operation(summary = "러닝 중 위치 저장", description = "러닝 세션 진행 중 현재 위치를 저장합니다. 로그인 필요")
+    public CommonResponse<Void> updateLocation(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long sessionId,
+            @Valid @RequestBody LocationUpdateReq request
+    ){
+        runSessionService.updateLocation(userId, sessionId, request);
+        return CommonResponse.success(null);
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
@@ -9,7 +9,12 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/run-sessions")
@@ -33,7 +38,7 @@ public class RunSessionController {
             @AuthenticationPrincipal Long userId,
             @PathVariable Long sessionId,
             @Valid @RequestBody LocationUpdateReq request
-    ){
+    ) {
         runSessionService.updateLocation(userId, sessionId, request);
         return CommonResponse.success(null);
     }

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/request/LocationUpdateReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/request/LocationUpdateReq.java
@@ -1,0 +1,32 @@
+package com._s3k.runsync.domain.run.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "러닝 중 위치 업데이트 요청")
+public class LocationUpdateReq {
+
+    @NotNull
+    @DecimalMin("-90.0") @DecimalMax("90.0")
+    @Schema(description = "현재(마지막) 위도", example = "36.3321")
+    private Double lastLatitude;
+
+    @NotNull
+    @DecimalMin("-180.0") @DecimalMax("180.0")
+    @Schema(description = "현재(마지막) 경도", example = "127.4562")
+    private Double lastLongitude;
+
+    @NotNull
+    @Schema(description = "현재까지 뛴 거리 (km)", example = "2.34")
+    private Double currentDistance;
+
+    @NotNull
+    @Schema(description = "현재까지 진행 시간 (초)", example = "754")
+    private Integer currentDurationTime;
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/request/LocationUpdateReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/request/LocationUpdateReq.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.DecimalMax;
 import jakarta.validation.constraints.DecimalMin;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,10 +24,12 @@ public class LocationUpdateReq {
     private Double lastLongitude;
 
     @NotNull
+    @PositiveOrZero
     @Schema(description = "현재까지 뛴 거리 (km)", example = "2.34")
     private Double currentDistance;
 
     @NotNull
+    @PositiveOrZero
     @Schema(description = "현재까지 진행 시간 (초)", example = "754")
     private Integer currentDurationTime;
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/exception/RunSessionErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/exception/RunSessionErrorCode.java
@@ -9,7 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum RunSessionErrorCode implements ResultCode {
 
-    ACTIVE_SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, 3001, "이미 진행 중인 러닝 세션이 있습니다.");
+    ACTIVE_SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, 3001, "이미 진행 중인 러닝 세션이 있습니다."),
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, 3002, "러닝 세션을 찾을 수 없습니다."),
+    SESSION_NOT_OWNER(HttpStatus.FORBIDDEN, 3003, "해당 러닝 세션에 대한 권한이 없습니다."),
+    SESSION_NOT_ACTIVE(HttpStatus.BAD_REQUEST, 3004, "진행 중인 러닝 세션이 아닙니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
@@ -51,7 +51,7 @@ public class RunSessionService {
     }
 
     @Transactional
-    public void updateLocation(Long userId, Long sessionId, LocationUpdateReq request){
+    public void updateLocation(Long userId, Long sessionId, LocationUpdateReq request) {
         RunningSession session = runningSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new GlobalException(RunSessionErrorCode.SESSION_NOT_FOUND));
 
@@ -67,5 +67,4 @@ public class RunSessionService {
 
         session.updateLocation(point, BigDecimal.valueOf(request.getCurrentDistance()), request.getCurrentDurationTime());
     }
-
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
@@ -1,5 +1,6 @@
 package com._s3k.runsync.domain.run.service;
 
+import com._s3k.runsync.domain.run.dto.request.LocationUpdateReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
 import com._s3k.runsync.domain.run.dto.response.RunSessionStartRes;
 import com._s3k.runsync.domain.run.exception.RunSessionErrorCode;
@@ -11,9 +12,15 @@ import com._s3k.runsync.entity.User;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
 import com._s3k.runsync.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
 
 @Service
 @RequiredArgsConstructor
@@ -21,6 +28,7 @@ public class RunSessionService {
 
     private final UserRepository userRepository;
     private final RunningSessionRepository runningSessionRepository;
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
 
     @Transactional
     public RunSessionStartRes createRunSession(Long userId, RunSessionStartReq request) {
@@ -41,4 +49,23 @@ public class RunSessionService {
             throw new GlobalException(RunSessionErrorCode.ACTIVE_SESSION_ALREADY_EXISTS);
         }
     }
+
+    @Transactional
+    public void updateLocation(Long userId, Long sessionId, LocationUpdateReq request){
+        RunningSession session = runningSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new GlobalException(RunSessionErrorCode.SESSION_NOT_FOUND));
+
+        if(!session.getUserId().equals(userId)) {
+            throw new GlobalException(RunSessionErrorCode.SESSION_NOT_OWNER);
+        }
+
+        if (session.getStatus() != RunningSessionStatus.ACTIVE) {
+            throw new GlobalException(RunSessionErrorCode.SESSION_NOT_ACTIVE);
+        }
+
+        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(request.getLastLongitude(), request.getLastLatitude()));
+
+        session.updateLocation(point, BigDecimal.valueOf(request.getCurrentDistance()), request.getCurrentDurationTime());
+    }
+
 }

--- a/src/main/java/com/_s3k/runsync/entity/RunningSession.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunningSession.java
@@ -37,6 +37,12 @@ public class RunningSession extends BaseEntity {
     @Column(name = "last_location", columnDefinition = "geometry(Point, 4326)")
     private Point lastLocation;
 
+    @Column(name = "current_duration_time")
+    private Integer currentDurationTime;
+
+    @Column(name = "user_id", insertable = false, updatable = false)
+    private Long userId;
+
     @Builder(access = AccessLevel.PRIVATE)
     private RunningSession(User user, LocalDateTime startTime) {
         this.user = user;
@@ -58,6 +64,12 @@ public class RunningSession extends BaseEntity {
         this.totalDistance = totalDistance;
     }
 
+    public void updateLocation(Point point, BigDecimal currentDistance, Integer currentDurationTime){
+        this.lastLocation = point;
+        this.totalDistance = currentDistance; // 러닝 완료 전까지 현재 거리를 totalDistance에 누적, 종료 시 최종값으로 덮어씀
+        this.currentDurationTime = currentDurationTime;
+    }
+
     public void pause() {
         this.status = RunningSessionStatus.PAUSED;
     }
@@ -66,7 +78,4 @@ public class RunningSession extends BaseEntity {
         this.status = RunningSessionStatus.ACTIVE;
     }
 
-    public void updateLastLocation(Point point) {
-        this.lastLocation = point;
-    }
 }

--- a/src/main/java/com/_s3k/runsync/entity/RunningSession.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunningSession.java
@@ -64,7 +64,7 @@ public class RunningSession extends BaseEntity {
         this.totalDistance = totalDistance;
     }
 
-    public void updateLocation(Point point, BigDecimal currentDistance, Integer currentDurationTime){
+    public void updateLocation(Point point, BigDecimal currentDistance, Integer currentDurationTime) {
         this.lastLocation = point;
         this.totalDistance = currentDistance; // 러닝 완료 전까지 현재 거리를 totalDistance에 누적, 종료 시 최종값으로 덮어씀
         this.currentDurationTime = currentDurationTime;

--- a/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
@@ -1,5 +1,6 @@
 package com._s3k.runsync.domain.run.service;
 
+import com._s3k.runsync.domain.run.dto.request.LocationUpdateReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
 import com._s3k.runsync.domain.run.dto.response.RunSessionStartRes;
 import com._s3k.runsync.domain.run.exception.RunSessionErrorCode;
@@ -17,6 +18,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
@@ -25,6 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -46,7 +49,7 @@ class RunSessionServiceTest {
         // given
         Long userId = 1L;
         RunSessionStartReq request = new RunSessionStartReq();
-        request.setStartTime(LocalDateTime.now());
+        ReflectionTestUtils.setField(request, "startTime", LocalDateTime.now());
 
         User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
@@ -67,7 +70,7 @@ class RunSessionServiceTest {
         // given
         Long userId = 1L;
         RunSessionStartReq request = new RunSessionStartReq();
-        request.setStartTime(LocalDateTime.now());
+        ReflectionTestUtils.setField(request, "startTime", LocalDateTime.now());
 
         given(userRepository.findById(userId)).willReturn(Optional.empty());
 
@@ -86,7 +89,7 @@ class RunSessionServiceTest {
         // given
         Long userId = 1L;
         RunSessionStartReq request = new RunSessionStartReq();
-        request.setStartTime(LocalDateTime.now());
+        ReflectionTestUtils.setField(request, "startTime", LocalDateTime.now());
 
         User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
@@ -99,5 +102,49 @@ class RunSessionServiceTest {
                         .isEqualTo(RunSessionErrorCode.ACTIVE_SESSION_ALREADY_EXISTS));
 
         verify(runningSessionRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 세션으로 위치 저장 시 예외 발생")
+    void updateLocation_sessionNotFound() {
+        // given
+        given(runningSessionRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.updateLocation(1L, 1L, new LocationUpdateReq()))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunSessionErrorCode.SESSION_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("다른 유저의 세션에 위치 저장 시 예외 발생")
+    void updateLocation_sessionNotOwner() {
+        // given
+        RunningSession session = mock(RunningSession.class);
+        given(session.getUserId()).willReturn(2L);
+        given(runningSessionRepository.findById(1L)).willReturn(Optional.of(session));
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.updateLocation(1L, 1L, new LocationUpdateReq()))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunSessionErrorCode.SESSION_NOT_OWNER));
+    }
+
+    @Test
+    @DisplayName("ACTIVE 상태가 아닌 세션에 위치 저장 시 예외 발생")
+    void updateLocation_sessionNotActive() {
+        // given
+        RunningSession session = mock(RunningSession.class);
+        given(session.getUserId()).willReturn(1L);
+        given(session.getStatus()).willReturn(RunningSessionStatus.COMPLETED);
+        given(runningSessionRepository.findById(1L)).willReturn(Optional.of(session));
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.updateLocation(1L, 1L, new LocationUpdateReq()))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunSessionErrorCode.SESSION_NOT_ACTIVE));
     }
 }

--- a/src/test/java/com/_s3k/runsync/entity/RunningSessionTest.java
+++ b/src/test/java/com/_s3k/runsync/entity/RunningSessionTest.java
@@ -1,0 +1,36 @@
+package com._s3k.runsync.entity;
+
+import com._s3k.runsync.entity.enums.Provider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RunningSessionTest {
+
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
+
+    @Test
+    @DisplayName("위치 업데이트 시 lastLocation, totalDistance, currentDurationTime이 갱신된다")
+    void updateLocation() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession session = RunningSession.of(user, LocalDateTime.now());
+        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(127.4562, 36.3321));
+
+        // when
+        session.updateLocation(point, BigDecimal.valueOf(2.34), 754);
+
+        // then
+        assertThat(session.getLastLocation()).isEqualTo(point);
+        assertThat(session.getTotalDistance()).isEqualByComparingTo(BigDecimal.valueOf(2.34));
+        assertThat(session.getCurrentDurationTime()).isEqualTo(754);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #11

## 📝작업 내용

- `PATCH /api/run-sessions/{sessionId}/location` API 구현
- 본인 세션 여부 및 ACTIVE 상태 검증 로직 추가
- `RunningSession` 엔티티에 `currentDurationTime` 필드 추가
- 불필요한 User 조회 제거 (`userId` 필드 직접 매핑으로 개선)
- 좌표 유효성 검증 추가 (`@DecimalMin`, `@DecimalMax`)
- 서비스 에러 케이스 및 엔티티 단위 테스트 작성

## 📷스크린샷 (선택)

<img width="1423" height="783" alt="image" src="https://github.com/user-attachments/assets/f2531bbb-9f98-4cb1-b073-d5c7b9ea1d6c" />
<img width="1399" height="470" alt="image" src="https://github.com/user-attachments/assets/9c0b3427-287a-402b-8f86-da4e6d09d44e" />


## 💬리뷰 요구사항(선택)