### PR TITLE
[Feat] 러닝 종료 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/location/handler/LocationMessageHandler.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/handler/LocationMessageHandler.java
@@ -1,5 +1,6 @@
 package com._s3k.runsync.domain.location.handler;
 
+import com._s3k.runsync.domain.run.service.RunSessionService;
 import com._s3k.runsync.global.exception.GlobalException;
 import com._s3k.runsync.global.websocket.dto.WebSocketMessage;
 import com._s3k.runsync.domain.location.dto.request.LocationUpdateReq;
@@ -21,6 +22,7 @@ public class LocationMessageHandler {
 
     private final SimpMessagingTemplate messagingTemplate;
     private final LocationService locationService;
+    private final RunSessionService runSessionService;
 
     @MessageMapping("/location")
     public void handleLocation(WebSocketMessage<LocationUpdateReq> message, Principal principal) {
@@ -28,7 +30,15 @@ public class LocationMessageHandler {
         Long userId = Long.parseLong(principal.getName());
         LocationUpdateReq data = message.getData();
 
-        locationService.saveLocation(userId, data);
+        locationService.saveGeoLocation(userId, data);
+        if (data.getSessionId() != null) {
+            runSessionService.appendPath(
+                    data.getSessionId(),
+                    data.getLatitude(),
+                    data.getLongitude(),
+                    data.getSpeed() != null ? data.getSpeed() : 0.0
+            );
+        }
 
         Set<String> friendIds = locationService.getFriendIds(userId);
         if (friendIds.isEmpty()) return;

--- a/src/main/java/com/_s3k/runsync/domain/location/repository/LocationRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/repository/LocationRepository.java
@@ -6,8 +6,6 @@ public interface LocationRepository {
 
     void saveGeoLocation(Long userId, double longitude, double latitude);
 
-    void appendPath(Long sessionId, double latitude, double longitude, double speed);
-
     Set<String> findFriendIds(Long userId);
 
     void deleteGeoLocation(Long userId);

--- a/src/main/java/com/_s3k/runsync/domain/location/repository/LocationRepositoryImpl.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/repository/LocationRepositoryImpl.java
@@ -2,15 +2,11 @@ package com._s3k.runsync.domain.location.repository;
 
 import com._s3k.runsync.domain.location.exception.LocationErrorCode;
 import com._s3k.runsync.global.exception.GlobalException;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.geo.Point;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
-import java.time.Instant;
-import java.util.Map;
 import java.util.Set;
 
 @Repository
@@ -18,29 +14,11 @@ import java.util.Set;
 public class LocationRepositoryImpl implements LocationRepository {
 
     private final StringRedisTemplate redisTemplate;
-    private final ObjectMapper objectMapper;
 
     @Override
     public void saveGeoLocation(Long userId, double longitude, double latitude) {
         try {
             redisTemplate.opsForGeo().add("user:locations", new Point(longitude, latitude), String.valueOf(userId));
-        } catch (Exception e) {
-            throw new GlobalException(LocationErrorCode.LOCATION_SAVE_FAILED);
-        }
-    }
-
-    @Override
-    public void appendPath(Long sessionId, double latitude, double longitude, double speed) {
-        String pathJson = toJson(Map.of(
-                "lat", latitude,
-                "lng", longitude,
-                "speed", speed,
-                "recordedAt", Instant.now().toString()
-        ));
-        String key = "run_session:" + sessionId + ":paths";
-        try {
-            redisTemplate.opsForList().rightPush(key, pathJson);
-            redisTemplate.expire(key, java.time.Duration.ofDays(1));
         } catch (Exception e) {
             throw new GlobalException(LocationErrorCode.LOCATION_SAVE_FAILED);
         }
@@ -56,11 +34,4 @@ public class LocationRepositoryImpl implements LocationRepository {
         redisTemplate.opsForGeo().remove("user:locations", String.valueOf(userId));
     }
 
-    private String toJson(Object obj) {
-        try {
-            return objectMapper.writeValueAsString(obj);
-        } catch (JsonProcessingException e) {
-            throw new GlobalException(LocationErrorCode.LOCATION_SAVE_FAILED);
-        }
-    }
 }

--- a/src/main/java/com/_s3k/runsync/domain/location/service/LocationService.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/service/LocationService.java
@@ -15,18 +15,12 @@ public class LocationService {
 
     private final LocationRepository locationRepository;
 
-    public void saveLocation(Long userId, LocationUpdateReq data) {
-        if (data == null || data.getLatitude() == null || data.getLongitude() == null || data.getSessionId() == null) {
+    public void saveGeoLocation(Long userId, LocationUpdateReq data) {
+        if (data == null || data.getLatitude() == null || data.getLongitude() == null) {
             throw new GlobalException(LocationErrorCode.INVALID_LOCATION_DATA);
         }
 
         locationRepository.saveGeoLocation(userId, data.getLongitude(), data.getLatitude());
-        locationRepository.appendPath(
-                data.getSessionId(),
-                data.getLatitude(),
-                data.getLongitude(),
-                data.getSpeed() != null ? data.getSpeed() : 0.0
-        );
     }
 
     public Set<String> getFriendIds(Long userId) {

--- a/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
@@ -1,7 +1,9 @@
 package com._s3k.runsync.domain.run.controller;
 
 import com._s3k.runsync.domain.run.dto.request.LocationUpdateReq;
+import com._s3k.runsync.domain.run.dto.request.RunSessionEndReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
+import com._s3k.runsync.domain.run.dto.response.RunSessionEndRes;
 import com._s3k.runsync.domain.run.dto.response.RunSessionStartRes;
 import com._s3k.runsync.domain.run.service.RunSessionService;
 import com._s3k.runsync.global.common.dto.CommonResponse;
@@ -41,5 +43,15 @@ public class RunSessionController {
     ) {
         runSessionService.updateLocation(userId, sessionId, request);
         return CommonResponse.success(null);
+    }
+
+    @PatchMapping("/{sessionId}")
+    @Operation(summary = "러닝 종료", description = "러닝 세션을 종료합니다. 로그인 필요")
+    public CommonResponse<RunSessionEndRes> endRunSession(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long sessionId,
+            @Valid @RequestBody RunSessionEndReq request
+    ) {
+        return CommonResponse.success(runSessionService.endRunSession(userId, sessionId, request));
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunSessionEndReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunSessionEndReq.java
@@ -1,6 +1,8 @@
 package com._s3k.runsync.domain.run.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,9 +13,12 @@ import java.time.LocalDateTime;
 @Schema(description = "러닝 종료 요청")
 public class RunSessionEndReq {
 
+    @NotNull
     @Schema(description = "러닝 종료 시간", example = "2026-05-13T09:00:00")
     private LocalDateTime endTime;
 
+    @NotNull
+    @PositiveOrZero
     @Schema(description = "최종 이동 거리(km)", example = "10.09")
     private Double totalDistance;
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunSessionEndReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunSessionEndReq.java
@@ -1,0 +1,19 @@
+package com._s3k.runsync.domain.run.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "러닝 종료 요청")
+public class RunSessionEndReq {
+
+    @Schema(description = "러닝 종료 시간", example = "2026-05-13T09:00:00")
+    private LocalDateTime endTime;
+
+    @Schema(description = "최종 이동 거리(km)", example = "10.09")
+    private Double totalDistance;
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunSessionEndRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunSessionEndRes.java
@@ -1,0 +1,26 @@
+package com._s3k.runsync.domain.run.dto.response;
+
+import com._s3k.runsync.entity.RunningSession;
+import com._s3k.runsync.entity.enums.RunningSessionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "러닝 세션 종료 응답")
+public class RunSessionEndRes {
+
+    @Schema(description = "세션 ID", example = "1")
+    private final Long sessionId;
+
+    @Schema(description = "변경된 세션 상태", example = "COMPLETED")
+    private final RunningSessionStatus status;
+
+    private RunSessionEndRes(Long sessionId, RunningSessionStatus status) {
+        this.sessionId = sessionId;
+        this.status = status;
+    }
+
+    public static RunSessionEndRes of(RunningSession session) {
+        return new RunSessionEndRes(session.getId(), session.getStatus());
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/exception/RunSessionErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/exception/RunSessionErrorCode.java
@@ -13,7 +13,8 @@ public enum RunSessionErrorCode implements ResultCode {
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, 3002, "러닝 세션을 찾을 수 없습니다."),
     SESSION_NOT_OWNER(HttpStatus.FORBIDDEN, 3003, "해당 러닝 세션에 대한 권한이 없습니다."),
     SESSION_NOT_ACTIVE(HttpStatus.BAD_REQUEST, 3004, "진행 중인 러닝 세션이 아닙니다."),
-    PATH_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 3005, "러닝 경로 처리에 실패했습니다.");
+    PATH_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 3005, "러닝 경로 처리에 실패했습니다."),
+    PATH_SERIALIZE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 3006, "경로 직렬화에 실패했습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/domain/run/exception/RunSessionErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/exception/RunSessionErrorCode.java
@@ -12,7 +12,8 @@ public enum RunSessionErrorCode implements ResultCode {
     ACTIVE_SESSION_ALREADY_EXISTS(HttpStatus.CONFLICT, 3001, "이미 진행 중인 러닝 세션이 있습니다."),
     SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, 3002, "러닝 세션을 찾을 수 없습니다."),
     SESSION_NOT_OWNER(HttpStatus.FORBIDDEN, 3003, "해당 러닝 세션에 대한 권한이 없습니다."),
-    SESSION_NOT_ACTIVE(HttpStatus.BAD_REQUEST, 3004, "진행 중인 러닝 세션이 아닙니다.");
+    SESSION_NOT_ACTIVE(HttpStatus.BAD_REQUEST, 3004, "진행 중인 러닝 세션이 아닙니다."),
+    PATH_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 3005, "러닝 경로 처리에 실패했습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
@@ -1,0 +1,7 @@
+package com._s3k.runsync.domain.run.repository;
+
+import com._s3k.runsync.entity.RunRecord;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RunRecordRepository extends JpaRepository<RunRecord, Long> {
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/repository/RunSessionRedisRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/RunSessionRedisRepository.java
@@ -1,0 +1,14 @@
+package com._s3k.runsync.domain.run.repository;
+
+import java.util.List;
+
+public interface RunSessionRedisRepository {
+
+    void appendPath(Long sessionId, double latitude, double longitude, double speed);
+
+    List<String> getPaths(Long sessionId);
+
+    void deletePaths(Long sessionId);
+
+    void deleteState(Long sessionId);
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/repository/RunSessionRedisRepositoryImpl.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/RunSessionRedisRepositoryImpl.java
@@ -1,0 +1,53 @@
+package com._s3k.runsync.domain.run.repository;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+@Repository
+@RequiredArgsConstructor
+public class RunSessionRedisRepositoryImpl implements RunSessionRedisRepository {
+
+    private final StringRedisTemplate redisTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void appendPath(Long sessionId, double latitude, double longitude, double speed) {
+        String key = "run_session:" + sessionId + ":paths";
+        try {
+            String pathJson = objectMapper.writeValueAsString(Map.of(
+                    "lat", latitude,
+                    "lng", longitude,
+                    "speed", speed,
+                    "recordedAt", Instant.now().toString()
+            ));
+            redisTemplate.opsForList().rightPush(key, pathJson);
+            redisTemplate.expire(key, Duration.ofDays(1));
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("경로 직렬화 실패", e);
+        }
+    }
+
+    @Override
+    public List<String> getPaths(Long sessionId) {
+        List<String> paths = redisTemplate.opsForList().range("run_session:" + sessionId + ":paths", 0, -1);
+        return paths != null ? paths : List.of();
+    }
+
+    @Override
+    public void deletePaths(Long sessionId) {
+        redisTemplate.delete("run_session:" + sessionId + ":paths");
+    }
+
+    @Override
+    public void deleteState(Long sessionId) {
+        redisTemplate.delete("run_session:" + sessionId + ":state");
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/repository/RunSessionRedisRepositoryImpl.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/RunSessionRedisRepositoryImpl.java
@@ -1,5 +1,7 @@
 package com._s3k.runsync.domain.run.repository;
 
+import com._s3k.runsync.domain.run.exception.RunSessionErrorCode;
+import com._s3k.runsync.global.exception.GlobalException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
@@ -20,7 +22,6 @@ public class RunSessionRedisRepositoryImpl implements RunSessionRedisRepository 
 
     @Override
     public void appendPath(Long sessionId, double latitude, double longitude, double speed) {
-        String key = "run_session:" + sessionId + ":paths";
         try {
             String pathJson = objectMapper.writeValueAsString(Map.of(
                     "lat", latitude,
@@ -28,26 +29,34 @@ public class RunSessionRedisRepositoryImpl implements RunSessionRedisRepository 
                     "speed", speed,
                     "recordedAt", Instant.now().toString()
             ));
-            redisTemplate.opsForList().rightPush(key, pathJson);
-            redisTemplate.expire(key, Duration.ofDays(1));
+            redisTemplate.opsForList().rightPush(pathKey(sessionId), pathJson);
+            redisTemplate.expire(pathKey(sessionId), Duration.ofDays(1));
         } catch (JsonProcessingException e) {
-            throw new RuntimeException("경로 직렬화 실패", e);
+            throw new GlobalException(RunSessionErrorCode.PATH_SERIALIZE_FAILED);
         }
     }
 
     @Override
     public List<String> getPaths(Long sessionId) {
-        List<String> paths = redisTemplate.opsForList().range("run_session:" + sessionId + ":paths", 0, -1);
+        List<String> paths = redisTemplate.opsForList().range(pathKey(sessionId), 0, -1);
         return paths != null ? paths : List.of();
     }
 
     @Override
     public void deletePaths(Long sessionId) {
-        redisTemplate.delete("run_session:" + sessionId + ":paths");
+        redisTemplate.delete(pathKey(sessionId));
     }
 
     @Override
     public void deleteState(Long sessionId) {
-        redisTemplate.delete("run_session:" + sessionId + ":state");
+        redisTemplate.delete(stateKey(sessionId));
+    }
+
+    private String pathKey(Long sessionId) {
+        return "run_session:" + sessionId + ":paths";
+    }
+
+    private String stateKey(Long sessionId) {
+        return "run_session:" + sessionId + ":state";
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
@@ -38,6 +38,8 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class RunSessionService {
 
+    private static final TypeReference<Map<String, Object>> PATH_TYPE_REF = new TypeReference<>() {};
+
     private final UserRepository userRepository;
     private final RunningSessionRepository runningSessionRepository;
     private final RunRecordRepository runRecordRepository;
@@ -123,7 +125,7 @@ public class RunSessionService {
         List<RunPath> paths = new ArrayList<>();
         for (int i = 0; i < pathJsonList.size(); i++) {
             try {
-                Map<String, Object> pathData = objectMapper.readValue(pathJsonList.get(i), new TypeReference<>() {});
+                Map<String, Object> pathData = objectMapper.readValue(pathJsonList.get(i), PATH_TYPE_REF);
                 double lat = ((Number) pathData.get("lat")).doubleValue();
                 double lng = ((Number) pathData.get("lng")).doubleValue();
                 double speed = ((Number) pathData.get("speed")).doubleValue();

--- a/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
@@ -1,26 +1,38 @@
 package com._s3k.runsync.domain.run.service;
 
+import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.domain.run.dto.request.LocationUpdateReq;
+import com._s3k.runsync.domain.run.dto.request.RunSessionEndReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
+import com._s3k.runsync.domain.run.dto.response.RunSessionEndRes;
 import com._s3k.runsync.domain.run.dto.response.RunSessionStartRes;
 import com._s3k.runsync.domain.run.exception.RunSessionErrorCode;
+import com._s3k.runsync.domain.run.repository.RunRecordRepository;
+import com._s3k.runsync.domain.run.repository.RunSessionRedisRepository;
 import com._s3k.runsync.domain.run.repository.RunningSessionRepository;
 import com._s3k.runsync.domain.users.exception.UserErrorCode;
 import com._s3k.runsync.domain.users.repository.UserRepository;
+import com._s3k.runsync.entity.RunPath;
+import com._s3k.runsync.entity.RunRecord;
 import com._s3k.runsync.entity.RunningSession;
 import com._s3k.runsync.entity.User;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
 import com._s3k.runsync.global.exception.GlobalException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.geom.PrecisionModel;
 import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneOffset;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -28,7 +40,11 @@ public class RunSessionService {
 
     private final UserRepository userRepository;
     private final RunningSessionRepository runningSessionRepository;
-    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
+    private final RunRecordRepository runRecordRepository;
+    private final RunSessionRedisRepository runSessionRedisRepository;
+    private final LocationService locationService;
+    private final ObjectMapper objectMapper;
+
 
     @Transactional
     public RunSessionStartRes createRunSession(Long userId, RunSessionStartReq request) {
@@ -50,12 +66,16 @@ public class RunSessionService {
         }
     }
 
+    public void appendPath(Long sessionId, double latitude, double longitude, double speed) {
+        runSessionRedisRepository.appendPath(sessionId, latitude, longitude, speed);
+    }
+
     @Transactional
     public void updateLocation(Long userId, Long sessionId, LocationUpdateReq request) {
         RunningSession session = runningSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new GlobalException(RunSessionErrorCode.SESSION_NOT_FOUND));
 
-        if(!session.getUserId().equals(userId)) {
+        if (!session.getUserId().equals(userId)) {
             throw new GlobalException(RunSessionErrorCode.SESSION_NOT_OWNER);
         }
 
@@ -63,8 +83,59 @@ public class RunSessionService {
             throw new GlobalException(RunSessionErrorCode.SESSION_NOT_ACTIVE);
         }
 
-        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(request.getLastLongitude(), request.getLastLatitude()));
+        session.updateLocation(request.getLastLatitude(), request.getLastLongitude(),
+                BigDecimal.valueOf(request.getCurrentDistance()), request.getCurrentDurationTime());
+    }
 
-        session.updateLocation(point, BigDecimal.valueOf(request.getCurrentDistance()), request.getCurrentDurationTime());
+    @Transactional
+    public RunSessionEndRes endRunSession(Long userId, Long sessionId, RunSessionEndReq request) {
+        RunningSession session = runningSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new GlobalException(RunSessionErrorCode.SESSION_NOT_FOUND));
+
+        if (!session.getUserId().equals(userId)) {
+            throw new GlobalException(RunSessionErrorCode.SESSION_NOT_OWNER);
+        }
+
+        if (session.getStatus() != RunningSessionStatus.ACTIVE) {
+            throw new GlobalException(RunSessionErrorCode.SESSION_NOT_ACTIVE);
+        }
+
+        BigDecimal totalDistance = BigDecimal.valueOf(request.getTotalDistance());
+        session.complete(request.getEndTime(), totalDistance);
+
+        RunRecord runRecord = session.createRecord(totalDistance);
+
+        List<String> pathJsonList = runSessionRedisRepository.getPaths(sessionId);
+        if (!pathJsonList.isEmpty()) {
+            runRecord.addPaths(parsePaths(pathJsonList, runRecord));
+        }
+
+        runRecordRepository.save(runRecord);
+
+        runSessionRedisRepository.deletePaths(sessionId);
+        runSessionRedisRepository.deleteState(sessionId);
+        locationService.removeLocation(userId);
+
+        return RunSessionEndRes.of(session);
+    }
+
+    private List<RunPath> parsePaths(List<String> pathJsonList, RunRecord runRecord) {
+        List<RunPath> paths = new ArrayList<>();
+        for (int i = 0; i < pathJsonList.size(); i++) {
+            try {
+                Map<String, Object> pathData = objectMapper.readValue(pathJsonList.get(i), new TypeReference<>() {});
+                double lat = ((Number) pathData.get("lat")).doubleValue();
+                double lng = ((Number) pathData.get("lng")).doubleValue();
+                double speed = ((Number) pathData.get("speed")).doubleValue();
+                LocalDateTime recordedAt = LocalDateTime.ofInstant(
+                        Instant.parse((String) pathData.get("recordedAt")), ZoneOffset.UTC);
+                BigDecimal speedKmh = BigDecimal.valueOf(speed * 3.6).setScale(2, RoundingMode.HALF_UP);
+
+                paths.add(RunPath.of(runRecord, lat, lng, i + 1, recordedAt, null, speedKmh, null, null));
+            } catch (Exception e) {
+                throw new GlobalException(RunSessionErrorCode.PATH_PARSE_FAILED);
+            }
+        }
+        return paths;
     }
 }

--- a/src/main/java/com/_s3k/runsync/entity/RunPath.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunPath.java
@@ -5,7 +5,10 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -17,6 +20,8 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RunPath extends BaseEntity {
+
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "record_id", nullable = false)
@@ -56,11 +61,12 @@ public class RunPath extends BaseEntity {
         this.accuracyM = accuracyM;
     }
 
-    public static RunPath of(RunRecord runRecord, Point location, Integer sequence, LocalDateTime recordedAt,
-                             BigDecimal altitudeM, BigDecimal speedKmh, BigDecimal paceMinPerKm, BigDecimal accuracyM) {
+    public static RunPath of(RunRecord runRecord, double latitude, double longitude, Integer sequence,
+                             LocalDateTime recordedAt, BigDecimal altitudeM, BigDecimal speedKmh,
+                             BigDecimal paceMinPerKm, BigDecimal accuracyM) {
         return RunPath.builder()
                 .runRecord(runRecord)
-                .location(location)
+                .location(GEOMETRY_FACTORY.createPoint(new Coordinate(longitude, latitude)))
                 .sequence(sequence)
                 .recordedAt(recordedAt)
                 .altitudeM(altitudeM)

--- a/src/main/java/com/_s3k/runsync/entity/RunRecord.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunRecord.java
@@ -8,6 +8,8 @@ import lombok.NoArgsConstructor;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 @Entity
 @Table(name = "run_records")
@@ -47,6 +49,9 @@ public class RunRecord extends BaseEntity {
     @Column(name = "cadence")
     private Integer cadence;
 
+    @OneToMany(mappedBy = "runRecord", cascade = CascadeType.PERSIST)
+    private List<RunPath> paths = new ArrayList<>();
+
     @Builder(access = AccessLevel.PRIVATE)
     private RunRecord(User user, RunningSession runningSession, Integer durationSeconds,
                       LocalDateTime startTime, BigDecimal distance, BigDecimal averagePace,
@@ -62,6 +67,11 @@ public class RunRecord extends BaseEntity {
         this.elevationGain = elevationGain;
         this.averageHeartRate = averageHeartRate;
         this.cadence = cadence;
+        this.paths = new ArrayList<>();
+    }
+
+    public void addPaths(List<RunPath> runPaths) {
+        this.paths.addAll(runPaths);
     }
 
     public static RunRecord of(User user, RunningSession runningSession, Integer durationSeconds,

--- a/src/main/java/com/_s3k/runsync/entity/RunningSession.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunningSession.java
@@ -6,7 +6,10 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -16,6 +19,8 @@ import java.time.LocalDateTime;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RunningSession extends BaseEntity {
+
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -64,10 +69,21 @@ public class RunningSession extends BaseEntity {
         this.totalDistance = totalDistance;
     }
 
-    public void updateLocation(Point point, BigDecimal currentDistance, Integer currentDurationTime) {
-        this.lastLocation = point;
-        this.totalDistance = currentDistance; // 러닝 완료 전까지 현재 거리를 totalDistance에 누적, 종료 시 최종값으로 덮어씀
+    public void updateLocation(double latitude, double longitude, BigDecimal currentDistance, Integer currentDurationTime) {
+        this.lastLocation = GEOMETRY_FACTORY.createPoint(new Coordinate(longitude, latitude));
+        this.totalDistance = currentDistance;
         this.currentDurationTime = currentDurationTime;
+    }
+
+    public RunRecord createRecord(BigDecimal totalDistance) {
+        return RunRecord.of(
+                this.user,
+                this,
+                this.currentDurationTime != null ? this.currentDurationTime : 0,
+                this.startTime,
+                totalDistance,
+                null, null, null, null, null
+        );
     }
 
     public void pause() {

--- a/src/test/java/com/_s3k/runsync/domain/location/repository/LocationRepositoryImplTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/location/repository/LocationRepositoryImplTest.java
@@ -2,8 +2,6 @@ package com._s3k.runsync.domain.location.repository;
 
 import com._s3k.runsync.domain.location.exception.LocationErrorCode;
 import com._s3k.runsync.global.exception.GlobalException;
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -12,7 +10,6 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.geo.Point;
 import org.springframework.data.redis.core.GeoOperations;
-import org.springframework.data.redis.core.ListOperations;
 import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
 
@@ -35,9 +32,6 @@ class LocationRepositoryImplTest {
 
     @Mock
     private StringRedisTemplate redisTemplate;
-
-    @Mock
-    private ObjectMapper objectMapper;
 
     @Test
     @DisplayName("위치 Geo 저장 성공")
@@ -63,50 +57,6 @@ class LocationRepositoryImplTest {
 
         // when & then
         assertThatThrownBy(() -> locationRepository.saveGeoLocation(1L, 126.9780, 37.5665))
-                .isInstanceOf(GlobalException.class)
-                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
-                        .isEqualTo(LocationErrorCode.LOCATION_SAVE_FAILED));
-    }
-
-    @Test
-    @DisplayName("경로 저장 성공")
-    void appendPath_success() throws JsonProcessingException {
-        // given
-        ListOperations<String, String> listOps = mock(ListOperations.class);
-        given(redisTemplate.opsForList()).willReturn(listOps);
-        given(objectMapper.writeValueAsString(any())).willReturn("{\"lat\":37.5665}");
-
-        // when
-        locationRepository.appendPath(1L, 37.5665, 126.9780, 3.5);
-
-        // then
-        verify(listOps).rightPush(anyString(), anyString());
-    }
-
-    @Test
-    @DisplayName("경로 저장 중 Redis 오류 시 예외 발생")
-    void appendPath_redisError_throwsException() throws JsonProcessingException {
-        // given
-        ListOperations<String, String> listOps = mock(ListOperations.class);
-        given(redisTemplate.opsForList()).willReturn(listOps);
-        given(objectMapper.writeValueAsString(any())).willReturn("{\"lat\":37.5665}");
-        given(listOps.rightPush(anyString(), anyString())).willThrow(RuntimeException.class);
-
-        // when & then
-        assertThatThrownBy(() -> locationRepository.appendPath(1L, 37.5665, 126.9780, 3.5))
-                .isInstanceOf(GlobalException.class)
-                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
-                        .isEqualTo(LocationErrorCode.LOCATION_SAVE_FAILED));
-    }
-
-    @Test
-    @DisplayName("JSON 변환 실패 시 예외 발생")
-    void appendPath_jsonError_throwsException() throws JsonProcessingException {
-        // given
-        given(objectMapper.writeValueAsString(any())).willThrow(JsonProcessingException.class);
-
-        // when & then
-        assertThatThrownBy(() -> locationRepository.appendPath(1L, 37.5665, 126.9780, 3.5))
                 .isInstanceOf(GlobalException.class)
                 .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
                         .isEqualTo(LocationErrorCode.LOCATION_SAVE_FAILED));

--- a/src/test/java/com/_s3k/runsync/domain/location/service/LocationServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/location/service/LocationServiceTest.java
@@ -38,37 +38,23 @@ class LocationServiceTest {
     }
 
     @Test
-    @DisplayName("위치 저장 성공")
-    void saveLocation_success() {
+    @DisplayName("GEO 위치 저장 성공")
+    void saveGeoLocation_success() {
         // given
         LocationUpdateReq req = createReq(1L, 37.5665, 126.9780, 3.5);
 
         // when
-        locationService.saveLocation(1L, req);
+        locationService.saveGeoLocation(1L, req);
 
         // then
         verify(locationRepository).saveGeoLocation(1L, 126.9780, 37.5665);
-        verify(locationRepository).appendPath(1L, 37.5665, 126.9780, 3.5);
-    }
-
-    @Test
-    @DisplayName("speed가 null이면 0.0으로 저장")
-    void saveLocation_speedNull_defaultsToZero() {
-        // given
-        LocationUpdateReq req = createReq(1L, 37.5665, 126.9780, null);
-
-        // when
-        locationService.saveLocation(1L, req);
-
-        // then
-        verify(locationRepository).appendPath(1L, 37.5665, 126.9780, 0.0);
     }
 
     @Test
     @DisplayName("data가 null이면 예외 발생")
-    void saveLocation_dataNul_throwsException() {
+    void saveGeoLocation_dataNullThrowsException() {
         // when & then
-        assertThatThrownBy(() -> locationService.saveLocation(1L, null))
+        assertThatThrownBy(() -> locationService.saveGeoLocation(1L, null))
                 .isInstanceOf(GlobalException.class)
                 .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
                         .isEqualTo(LocationErrorCode.INVALID_LOCATION_DATA));
@@ -78,12 +64,12 @@ class LocationServiceTest {
 
     @Test
     @DisplayName("위도가 null이면 예외 발생")
-    void saveLocation_latitudeNull_throwsException() {
+    void saveGeoLocation_latitudeNullThrowsException() {
         // given
         LocationUpdateReq req = createReq(1L, null, 126.9780, 3.5);
 
         // when & then
-        assertThatThrownBy(() -> locationService.saveLocation(1L, req))
+        assertThatThrownBy(() -> locationService.saveGeoLocation(1L, req))
                 .isInstanceOf(GlobalException.class)
                 .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
                         .isEqualTo(LocationErrorCode.INVALID_LOCATION_DATA));
@@ -93,27 +79,12 @@ class LocationServiceTest {
 
     @Test
     @DisplayName("경도가 null이면 예외 발생")
-    void saveLocation_longitudeNull_throwsException() {
+    void saveGeoLocation_longitudeNullThrowsException() {
         // given
         LocationUpdateReq req = createReq(1L, 37.5665, null, 3.5);
 
         // when & then
-        assertThatThrownBy(() -> locationService.saveLocation(1L, req))
-                .isInstanceOf(GlobalException.class)
-                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
-                        .isEqualTo(LocationErrorCode.INVALID_LOCATION_DATA));
-
-        verify(locationRepository, never()).saveGeoLocation(anyLong(), anyDouble(), anyDouble());
-    }
-
-    @Test
-    @DisplayName("세션 ID가 null이면 예외 발생")
-    void saveLocation_sessionIdNull_throwsException() {
-        // given
-        LocationUpdateReq req = createReq(null, 37.5665, 126.9780, 3.5);
-
-        // when & then
-        assertThatThrownBy(() -> locationService.saveLocation(1L, req))
+        assertThatThrownBy(() -> locationService.saveGeoLocation(1L, req))
                 .isInstanceOf(GlobalException.class)
                 .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
                         .isEqualTo(LocationErrorCode.INVALID_LOCATION_DATA));

--- a/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
@@ -1,26 +1,34 @@
 package com._s3k.runsync.domain.run.service;
 
+import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.domain.run.dto.request.LocationUpdateReq;
+import com._s3k.runsync.domain.run.dto.request.RunSessionEndReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
-import com._s3k.runsync.domain.run.dto.response.RunSessionStartRes;
 import com._s3k.runsync.domain.run.exception.RunSessionErrorCode;
+import com._s3k.runsync.domain.run.repository.RunRecordRepository;
+import com._s3k.runsync.domain.run.repository.RunSessionRedisRepository;
 import com._s3k.runsync.domain.run.repository.RunningSessionRepository;
 import com._s3k.runsync.domain.users.exception.UserErrorCode;
 import com._s3k.runsync.domain.users.repository.UserRepository;
+import com._s3k.runsync.entity.RunRecord;
 import com._s3k.runsync.entity.RunningSession;
 import com._s3k.runsync.entity.User;
 import com._s3k.runsync.entity.enums.Provider;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
 import com._s3k.runsync.global.exception.GlobalException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -43,6 +51,18 @@ class RunSessionServiceTest {
     @Mock
     private RunningSessionRepository runningSessionRepository;
 
+    @Mock
+    private RunRecordRepository runRecordRepository;
+
+    @Mock
+    private RunSessionRedisRepository runSessionRedisRepository;
+
+    @Mock
+    private LocationService locationService;
+
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+
     @Test
     @DisplayName("러닝 세션 생성 성공")
     void createRunSession_success() {
@@ -57,10 +77,9 @@ class RunSessionServiceTest {
         given(runningSessionRepository.save(any(RunningSession.class))).willAnswer(i -> i.getArgument(0));
 
         // when
-        RunSessionStartRes result = runSessionService.createRunSession(userId, request);
+        runSessionService.createRunSession(userId, request);
 
         // then
-        assertThat(result.getStatus()).isEqualTo(RunningSessionStatus.ACTIVE);
         verify(runningSessionRepository).save(any(RunningSession.class));
     }
 
@@ -146,5 +165,128 @@ class RunSessionServiceTest {
                 .isInstanceOf(GlobalException.class)
                 .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
                         .isEqualTo(RunSessionErrorCode.SESSION_NOT_ACTIVE));
+    }
+
+    @Test
+    @DisplayName("경로가 있는 러닝 종료 성공")
+    void endRunSession_success_withPaths() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        RunSessionEndReq request = new RunSessionEndReq();
+        ReflectionTestUtils.setField(request, "endTime", LocalDateTime.now());
+        ReflectionTestUtils.setField(request, "totalDistance", 5.0);
+
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession session = mock(RunningSession.class);
+        given(session.getUserId()).willReturn(userId);
+        given(session.getStatus()).willReturn(RunningSessionStatus.ACTIVE);
+        given(session.createRecord(any())).willReturn(
+                RunRecord.of(user, session, 0, LocalDateTime.now(), BigDecimal.valueOf(5.0), null, null, null, null, null)
+        );
+        given(runningSessionRepository.findById(sessionId)).willReturn(Optional.of(session));
+
+        String pathJson = "{\"lat\":37.5665,\"lng\":126.9780,\"speed\":3.5,\"recordedAt\":\"2026-05-13T02:43:10Z\"}";
+        given(runSessionRedisRepository.getPaths(sessionId)).willReturn(List.of(pathJson));
+
+        // when
+        runSessionService.endRunSession(userId, sessionId, request);
+
+        // then
+        verify(runRecordRepository).save(any(RunRecord.class));
+        verify(runSessionRedisRepository).deletePaths(sessionId);
+        verify(runSessionRedisRepository).deleteState(sessionId);
+        verify(locationService).removeLocation(userId);
+    }
+
+    @Test
+    @DisplayName("경로가 없는 러닝 종료 성공")
+    void endRunSession_success_withNoPaths() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        RunSessionEndReq request = new RunSessionEndReq();
+        ReflectionTestUtils.setField(request, "endTime", LocalDateTime.now());
+        ReflectionTestUtils.setField(request, "totalDistance", 5.0);
+
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession session = mock(RunningSession.class);
+        given(session.getUserId()).willReturn(userId);
+        given(session.getStatus()).willReturn(RunningSessionStatus.ACTIVE);
+        given(session.createRecord(any())).willReturn(
+                RunRecord.of(user, session, 0, LocalDateTime.now(), BigDecimal.valueOf(5.0), null, null, null, null, null)
+        );
+        given(runningSessionRepository.findById(sessionId)).willReturn(Optional.of(session));
+        given(runSessionRedisRepository.getPaths(sessionId)).willReturn(List.of());
+
+        // when
+        runSessionService.endRunSession(userId, sessionId, request);
+
+        // then
+        verify(runRecordRepository).save(any(RunRecord.class));
+        verify(runSessionRedisRepository).deletePaths(sessionId);
+        verify(runSessionRedisRepository).deleteState(sessionId);
+        verify(locationService).removeLocation(userId);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 세션으로 러닝 종료 시 예외 발생")
+    void endRunSession_sessionNotFound() {
+        // given
+        RunSessionEndReq request = new RunSessionEndReq();
+        ReflectionTestUtils.setField(request, "endTime", LocalDateTime.now());
+        ReflectionTestUtils.setField(request, "totalDistance", 5.0);
+        given(runningSessionRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.endRunSession(1L, 1L, request))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunSessionErrorCode.SESSION_NOT_FOUND));
+
+        verify(runRecordRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("다른 유저의 세션 종료 시 예외 발생")
+    void endRunSession_sessionNotOwner() {
+        // given
+        RunSessionEndReq request = new RunSessionEndReq();
+        ReflectionTestUtils.setField(request, "endTime", LocalDateTime.now());
+        ReflectionTestUtils.setField(request, "totalDistance", 5.0);
+
+        RunningSession session = mock(RunningSession.class);
+        given(session.getUserId()).willReturn(2L);
+        given(runningSessionRepository.findById(1L)).willReturn(Optional.of(session));
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.endRunSession(1L, 1L, request))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunSessionErrorCode.SESSION_NOT_OWNER));
+
+        verify(runRecordRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("ACTIVE 상태가 아닌 세션 종료 시 예외 발생")
+    void endRunSession_sessionNotActive() {
+        // given
+        RunSessionEndReq request = new RunSessionEndReq();
+        ReflectionTestUtils.setField(request, "endTime", LocalDateTime.now());
+        ReflectionTestUtils.setField(request, "totalDistance", 5.0);
+
+        RunningSession session = mock(RunningSession.class);
+        given(session.getUserId()).willReturn(1L);
+        given(session.getStatus()).willReturn(RunningSessionStatus.COMPLETED);
+        given(runningSessionRepository.findById(1L)).willReturn(Optional.of(session));
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.endRunSession(1L, 1L, request))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunSessionErrorCode.SESSION_NOT_ACTIVE));
+
+        verify(runRecordRepository, never()).save(any());
     }
 }

--- a/src/test/java/com/_s3k/runsync/entity/RunningSessionTest.java
+++ b/src/test/java/com/_s3k/runsync/entity/RunningSessionTest.java
@@ -1,12 +1,9 @@
 package com._s3k.runsync.entity;
 
 import com._s3k.runsync.entity.enums.Provider;
+import com._s3k.runsync.entity.enums.RunningSessionStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.locationtech.jts.geom.Coordinate;
-import org.locationtech.jts.geom.GeometryFactory;
-import org.locationtech.jts.geom.Point;
-import org.locationtech.jts.geom.PrecisionModel;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -15,7 +12,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class RunningSessionTest {
 
-    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
+    @Test
+    @DisplayName("세션 생성 시 초기 상태가 ACTIVE이다")
+    void createSession_initialStatusIsActive() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+
+        // when
+        RunningSession session = RunningSession.of(user, LocalDateTime.now());
+
+        // then
+        assertThat(session.getStatus()).isEqualTo(RunningSessionStatus.ACTIVE);
+    }
 
     @Test
     @DisplayName("위치 업데이트 시 lastLocation, totalDistance, currentDurationTime이 갱신된다")
@@ -23,14 +31,78 @@ class RunningSessionTest {
         // given
         User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
         RunningSession session = RunningSession.of(user, LocalDateTime.now());
-        Point point = GEOMETRY_FACTORY.createPoint(new Coordinate(127.4562, 36.3321));
 
         // when
-        session.updateLocation(point, BigDecimal.valueOf(2.34), 754);
+        session.updateLocation(36.3321, 127.4562, BigDecimal.valueOf(2.34), 754);
 
         // then
-        assertThat(session.getLastLocation()).isEqualTo(point);
+        assertThat(session.getLastLocation().getY()).isEqualTo(36.3321);  // Y = latitude
+        assertThat(session.getLastLocation().getX()).isEqualTo(127.4562); // X = longitude
         assertThat(session.getTotalDistance()).isEqualByComparingTo(BigDecimal.valueOf(2.34));
         assertThat(session.getCurrentDurationTime()).isEqualTo(754);
+    }
+
+    @Test
+    @DisplayName("complete 시 상태가 COMPLETED로 변경되고 종료 시간과 총 거리가 기록된다")
+    void complete() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession session = RunningSession.of(user, LocalDateTime.now());
+        LocalDateTime endTime = LocalDateTime.now().plusMinutes(30);
+
+        // when
+        session.complete(endTime, BigDecimal.valueOf(5.0));
+
+        // then
+        assertThat(session.getStatus()).isEqualTo(RunningSessionStatus.COMPLETED);
+        assertThat(session.getEndTime()).isEqualTo(endTime);
+        assertThat(session.getTotalDistance()).isEqualByComparingTo(BigDecimal.valueOf(5.0));
+    }
+
+    @Test
+    @DisplayName("pause 시 상태가 PAUSED로 변경된다")
+    void pause() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession session = RunningSession.of(user, LocalDateTime.now());
+
+        // when
+        session.pause();
+
+        // then
+        assertThat(session.getStatus()).isEqualTo(RunningSessionStatus.PAUSED);
+    }
+
+    @Test
+    @DisplayName("resume 시 상태가 ACTIVE로 변경된다")
+    void resume() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession session = RunningSession.of(user, LocalDateTime.now());
+        session.pause();
+
+        // when
+        session.resume();
+
+        // then
+        assertThat(session.getStatus()).isEqualTo(RunningSessionStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("createRecord 시 세션 정보로 RunRecord가 생성된다")
+    void createRecord() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        LocalDateTime startTime = LocalDateTime.now();
+        RunningSession session = RunningSession.of(user, startTime);
+        session.updateLocation(36.3321, 127.4562, BigDecimal.valueOf(2.0), 600);
+
+        // when
+        RunRecord record = session.createRecord(BigDecimal.valueOf(5.0));
+
+        // then
+        assertThat(record.getDurationSeconds()).isEqualTo(600);
+        assertThat(record.getStartTime()).isEqualTo(startTime);
+        assertThat(record.getDistance()).isEqualByComparingTo(BigDecimal.valueOf(5.0));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #13

## 📝작업 내용

### 1. 러닝 종료 API 구현 (`PATCH /api/run-sessions/{sessionId}`)
  - 세션 종료 시 Redis에 쌓인 경로 데이터를 `run_paths` 테이블에 일괄 저장
  - 저장 완료 후 Redis 경로 데이터 및 GEO 위치 정리

  ### 2. 도메인 중심 개발 적용
  - `RunningSession.createRecord()` — 세션이 직접 RunRecord를 생성
  - `RunRecord.addPaths()` — 경로 추가 책임을 엔티티에 배치
  - `RunningSession.updateLocation()` — 서비스가 Point를 만들어 넘기던 방식에서,
  엔티티가 좌표값을 받아 내부에서 Point를 생성하도록 변경

  ### 3. SOLID 리팩토링 (SRP)
  - `appendPath` 책임을 `LocationRepository` → `RunSessionRedisRepository`로 이동
    - 기존: `run_session:{id}:paths` 키를 두 Repository가 나눠서 관리 (쓰기/읽기
  분리)
    - 변경: 단일 Repository에서 쓰기·읽기·삭제 모두 담당

## 📷스크린샷 (선택)

<img width="1443" height="783" alt="스크린샷 2026-05-13 오전 11 55 29" src="https://github.com/user-attachments/assets/02304ba3-5ad2-4443-813a-a72c7dc0e251" />
<img width="1492" height="770" alt="스크린샷 2026-05-13 오후 12 08 16" src="https://github.com/user-attachments/assets/c173f0fa-196a-4ff2-bdc5-c155b9bff5ae" />
<img width="1110" height="460" alt="스크린샷 2026-05-13 오후 12 07 52" src="https://github.com/user-attachments/assets/404d93c0-c247-4255-9a05-8bc0feec0eb4" />
<img width="1153" height="212" alt="스크린샷 2026-05-13 오후 12 07 57" src="https://github.com/user-attachments/assets/1fc9f3db-2481-4357-90bb-0fc80bb31b48" />
<img width="1175" height="291" alt="스크린샷 2026-05-13 오후 12 08 03" src="https://github.com/user-attachments/assets/4d6b16bf-d05a-492b-820d-69e28bc03335" />