### PR TITLE
[Chore] edis TLS 설정 및 WebSocket 이벤트 예외 처리

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/location/handler/WebSocketEventListener.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/handler/WebSocketEventListener.java
@@ -5,6 +5,7 @@ import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.entity.enums.FriendStatus;
 import com._s3k.runsync.global.websocket.dto.WebSocketMessage;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
@@ -15,6 +16,7 @@ import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 import java.security.Principal;
 import java.util.Set;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class WebSocketEventListener {
@@ -49,6 +51,7 @@ public class WebSocketEventListener {
             friendIds = locationService.getFriendIds(userId);
         } catch (Exception e) {
             // 친구 목록 기능 미구현 상태에서 예외 발생 시 연결이 끊기는 것을 방지 (임시)
+            log.warn("친구 목록 조회 실패 userId={}: {}", userId, e.getMessage());
             return;
         }
         if (friendIds == null || friendIds.isEmpty()) return;

--- a/src/main/java/com/_s3k/runsync/domain/location/handler/WebSocketEventListener.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/handler/WebSocketEventListener.java
@@ -44,7 +44,13 @@ public class WebSocketEventListener {
     }
 
     private void notifyFriends(Long userId, FriendStatus status) {
-        Set<String> friendIds = locationService.getFriendIds(userId);
+        Set<String> friendIds;
+        try {
+            friendIds = locationService.getFriendIds(userId);
+        } catch (Exception e) {
+            // 친구 목록 기능 미구현 상태에서 예외 발생 시 연결이 끊기는 것을 방지 (임시)
+            return;
+        }
         if (friendIds == null || friendIds.isEmpty()) return;
 
         FriendStatusRes statusData = FriendStatusRes.of(userId, status);

--- a/src/main/java/com/_s3k/runsync/global/config/RedisConfig.java
+++ b/src/main/java/com/_s3k/runsync/global/config/RedisConfig.java
@@ -1,0 +1,31 @@
+package com._s3k.runsync.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+
+@Configuration
+public class RedisConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedisConnectionFactory redisConnectionFactory() {
+        RedisStandaloneConfiguration serverConfig = new RedisStandaloneConfiguration(host, port);
+
+        LettuceClientConfiguration clientConfig = LettuceClientConfiguration.builder()
+                .useSsl()
+                .disablePeerVerification()
+                .build();
+
+        return new LettuceConnectionFactory(serverConfig, clientConfig);
+    }
+}

--- a/src/main/java/com/_s3k/runsync/global/config/RedisConfig.java
+++ b/src/main/java/com/_s3k/runsync/global/config/RedisConfig.java
@@ -3,12 +3,14 @@ package com._s3k.runsync.global.config;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 
 @Configuration
+@Profile("local")
 public class RedisConfig {
 
     @Value("${spring.data.redis.host}")


### PR DESCRIPTION
## 📝작업 내용

- SSH 터널 환경에서 ElastiCache TLS 연결 시 호스트명 검증 오류 발생
- RedisConfig.java 추가로 TLS 유지하면서 호스트명 검증만 비활성화
- 친구 목록 미구현 상태에서 WebSocketEventListener 예외가 WebSocket 연결을 끊는 문제 임시 처리
