### PR TITLE
[Feat] 러닝 종료 후 세부 기록 입력 저장 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
@@ -1,8 +1,10 @@
 package com._s3k.runsync.domain.run.controller;
 
 import com._s3k.runsync.domain.run.dto.request.LocationUpdateReq;
+import com._s3k.runsync.domain.run.dto.request.RunRecordDetailReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionEndReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
+import com._s3k.runsync.domain.run.dto.response.RunRecordDetailRes;
 import com._s3k.runsync.domain.run.dto.response.RunSessionEndRes;
 import com._s3k.runsync.domain.run.dto.response.RunSessionStartRes;
 import com._s3k.runsync.domain.run.service.RunSessionService;
@@ -43,6 +45,16 @@ public class RunSessionController {
     ) {
         runSessionService.updateLocation(userId, sessionId, request);
         return CommonResponse.success(null);
+    }
+
+    @PostMapping("/{sessionId}/records")
+    @Operation(summary = "러닝 종료 후 세부 기록 입력 저장", description = "러닝 종료 후 세부 기록을 저장합니다. 로그인 필요")
+    public CommonResponse<RunRecordDetailRes> saveRunRecordDetail(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long sessionId,
+            @Valid @RequestBody RunRecordDetailReq request
+    ) {
+        return CommonResponse.success(runSessionService.saveRunRecordDetail(userId, sessionId, request));
     }
 
     @PatchMapping("/{sessionId}")

--- a/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
@@ -47,7 +47,7 @@ public class RunSessionController {
         return CommonResponse.success(null);
     }
 
-    @PostMapping("/{sessionId}/records")
+    @PatchMapping("/{sessionId}/records")
     @Operation(summary = "러닝 종료 후 세부 기록 입력 저장", description = "러닝 종료 후 세부 기록을 저장합니다. 로그인 필요")
     public CommonResponse<RunRecordDetailRes> saveRunRecordDetail(
             @AuthenticationPrincipal Long userId,

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunRecordDetailReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunRecordDetailReq.java
@@ -1,6 +1,7 @@
 package com._s3k.runsync.domain.run.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.PositiveOrZero;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -13,6 +14,7 @@ import java.math.BigDecimal;
 public class RunRecordDetailReq {
 
     @PositiveOrZero
+    @Digits(integer = 3, fraction = 2)
     @Schema(description = "평균 페이스(min/km)", example = "6.43")
     private Double averagePace;
 
@@ -29,6 +31,7 @@ public class RunRecordDetailReq {
     private Integer cadence;
 
     @PositiveOrZero
+    @Digits(integer = 5, fraction = 2)
     @Schema(description = "고도 상승(m)", example = "5.0")
     private Double elevationGain;
 

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunRecordDetailReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunRecordDetailReq.java
@@ -1,0 +1,42 @@
+package com._s3k.runsync.domain.run.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.math.BigDecimal;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "러닝 기록 세부 입력 요청")
+public class RunRecordDetailReq {
+
+    @PositiveOrZero
+    @Schema(description = "평균 페이스(min/km)", example = "6.43")
+    private Double averagePace;
+
+    @PositiveOrZero
+    @Schema(description = "소모 칼로리(kcal)", example = "450")
+    private Integer calories;
+
+    @PositiveOrZero
+    @Schema(description = "평균 심박수(bpm)", example = "172")
+    private Integer averageHeartRate;
+
+    @PositiveOrZero
+    @Schema(description = "케이던스(spm)", example = "167")
+    private Integer cadence;
+
+    @PositiveOrZero
+    @Schema(description = "고도 상승(m)", example = "5.0")
+    private Double elevationGain;
+
+    public BigDecimal getAveragePaceAsBigDecimal() {
+        return averagePace != null ? BigDecimal.valueOf(averagePace) : null;
+    }
+
+    public BigDecimal getElevationGainAsBigDecimal() {
+        return elevationGain != null ? BigDecimal.valueOf(elevationGain) : null;
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunRecordDetailRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunRecordDetailRes.java
@@ -1,0 +1,21 @@
+package com._s3k.runsync.domain.run.dto.response;
+
+import com._s3k.runsync.entity.RunRecord;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "러닝 기록 세부 입력 응답")
+public class RunRecordDetailRes {
+
+    @Schema(description = "러닝 기록 ID", example = "101")
+    private final Long recordId;
+
+    private RunRecordDetailRes(Long recordId) {
+        this.recordId = recordId;
+    }
+
+    public static RunRecordDetailRes of(RunRecord record) {
+        return new RunRecordDetailRes(record.getId());
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/exception/RunSessionErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/exception/RunSessionErrorCode.java
@@ -14,7 +14,9 @@ public enum RunSessionErrorCode implements ResultCode {
     SESSION_NOT_OWNER(HttpStatus.FORBIDDEN, 3003, "해당 러닝 세션에 대한 권한이 없습니다."),
     SESSION_NOT_ACTIVE(HttpStatus.BAD_REQUEST, 3004, "진행 중인 러닝 세션이 아닙니다."),
     PATH_PARSE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 3005, "러닝 경로 처리에 실패했습니다."),
-    PATH_SERIALIZE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 3006, "경로 직렬화에 실패했습니다.");
+    PATH_SERIALIZE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, 3006, "경로 직렬화에 실패했습니다."),
+    SESSION_NOT_COMPLETED(HttpStatus.BAD_REQUEST, 3007, "완료된 러닝 세션이 아닙니다."),
+    RUN_RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, 3008, "러닝 기록을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
@@ -3,5 +3,9 @@ package com._s3k.runsync.domain.run.repository;
 import com._s3k.runsync.entity.RunRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface RunRecordRepository extends JpaRepository<RunRecord, Long> {
+
+    Optional<RunRecord> findByRunningSessionId(Long sessionId);
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
@@ -2,8 +2,10 @@ package com._s3k.runsync.domain.run.service;
 
 import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.domain.run.dto.request.LocationUpdateReq;
+import com._s3k.runsync.domain.run.dto.request.RunRecordDetailReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionEndReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
+import com._s3k.runsync.domain.run.dto.response.RunRecordDetailRes;
 import com._s3k.runsync.domain.run.dto.response.RunSessionEndRes;
 import com._s3k.runsync.domain.run.dto.response.RunSessionStartRes;
 import com._s3k.runsync.domain.run.exception.RunSessionErrorCode;
@@ -68,6 +70,28 @@ public class RunSessionService {
         }
     }
 
+    @Transactional
+    public RunRecordDetailRes saveRunRecordDetail(Long userId, Long sessionId, RunRecordDetailReq request) {
+        RunningSession session = runningSessionRepository.findById(sessionId)
+                .orElseThrow(() -> new GlobalException(RunSessionErrorCode.SESSION_NOT_FOUND));
+
+        session.validateOwner(userId);
+        session.validateCompleted();
+
+        RunRecord record = runRecordRepository.findByRunningSessionId(sessionId)
+                .orElseThrow(() -> new GlobalException(RunSessionErrorCode.RUN_RECORD_NOT_FOUND));
+
+        record.updateDetails(
+                request.getAveragePaceAsBigDecimal(),
+                request.getCalories(),
+                request.getAverageHeartRate(),
+                request.getCadence(),
+                request.getElevationGainAsBigDecimal()
+        );
+
+        return RunRecordDetailRes.of(record);
+    }
+
     public void appendPath(Long sessionId, double latitude, double longitude, double speed) {
         runSessionRedisRepository.appendPath(sessionId, latitude, longitude, speed);
     }
@@ -77,13 +101,8 @@ public class RunSessionService {
         RunningSession session = runningSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new GlobalException(RunSessionErrorCode.SESSION_NOT_FOUND));
 
-        if (!session.getUserId().equals(userId)) {
-            throw new GlobalException(RunSessionErrorCode.SESSION_NOT_OWNER);
-        }
-
-        if (session.getStatus() != RunningSessionStatus.ACTIVE) {
-            throw new GlobalException(RunSessionErrorCode.SESSION_NOT_ACTIVE);
-        }
+        session.validateOwner(userId);
+        session.validateActive();
 
         session.updateLocation(request.getLastLatitude(), request.getLastLongitude(),
                 BigDecimal.valueOf(request.getCurrentDistance()), request.getCurrentDurationTime());
@@ -94,13 +113,8 @@ public class RunSessionService {
         RunningSession session = runningSessionRepository.findById(sessionId)
                 .orElseThrow(() -> new GlobalException(RunSessionErrorCode.SESSION_NOT_FOUND));
 
-        if (!session.getUserId().equals(userId)) {
-            throw new GlobalException(RunSessionErrorCode.SESSION_NOT_OWNER);
-        }
-
-        if (session.getStatus() != RunningSessionStatus.ACTIVE) {
-            throw new GlobalException(RunSessionErrorCode.SESSION_NOT_ACTIVE);
-        }
+        session.validateOwner(userId);
+        session.validateActive();
 
         BigDecimal totalDistance = BigDecimal.valueOf(request.getTotalDistance());
         session.complete(request.getEndTime(), totalDistance);

--- a/src/main/java/com/_s3k/runsync/entity/RunRecord.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunRecord.java
@@ -74,6 +74,15 @@ public class RunRecord extends BaseEntity {
         this.paths.addAll(runPaths);
     }
 
+    public void updateDetails(BigDecimal averagePace, Integer calories, Integer averageHeartRate,
+                              Integer cadence, BigDecimal elevationGain) {
+        if (averagePace != null) this.averagePace = averagePace;
+        if (calories != null) this.calories = calories;
+        if (averageHeartRate != null) this.averageHeartRate = averageHeartRate;
+        if (cadence != null) this.cadence = cadence;
+        if (elevationGain != null) this.elevationGain = elevationGain;
+    }
+
     public static RunRecord of(User user, RunningSession runningSession, Integer durationSeconds,
                                LocalDateTime startTime, BigDecimal distance, BigDecimal averagePace,
                                Integer calories, BigDecimal elevationGain, Integer averageHeartRate,

--- a/src/main/java/com/_s3k/runsync/entity/RunningSession.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunningSession.java
@@ -1,6 +1,8 @@
 package com._s3k.runsync.entity;
 
+import com._s3k.runsync.domain.run.exception.RunSessionErrorCode;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
+import com._s3k.runsync.global.exception.GlobalException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -84,6 +86,24 @@ public class RunningSession extends BaseEntity {
                 totalDistance,
                 null, null, null, null, null
         );
+    }
+
+    public void validateOwner(Long userId) {
+        if (!this.userId.equals(userId)) {
+            throw new GlobalException(RunSessionErrorCode.SESSION_NOT_OWNER);
+        }
+    }
+
+    public void validateActive() {
+        if (this.status != RunningSessionStatus.ACTIVE) {
+            throw new GlobalException(RunSessionErrorCode.SESSION_NOT_ACTIVE);
+        }
+    }
+
+    public void validateCompleted() {
+        if (this.status != RunningSessionStatus.COMPLETED) {
+            throw new GlobalException(RunSessionErrorCode.SESSION_NOT_COMPLETED);
+        }
     }
 
     public void pause() {

--- a/src/main/java/com/_s3k/runsync/entity/RunningSession.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunningSession.java
@@ -15,6 +15,7 @@ import org.locationtech.jts.geom.PrecisionModel;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Objects;
 
 @Entity
 @Table(name = "running_session")
@@ -89,7 +90,7 @@ public class RunningSession extends BaseEntity {
     }
 
     public void validateOwner(Long userId) {
-        if (!this.userId.equals(userId)) {
+        if (!Objects.equals(this.userId, userId)) {
             throw new GlobalException(RunSessionErrorCode.SESSION_NOT_OWNER);
         }
     }

--- a/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
@@ -2,6 +2,7 @@ package com._s3k.runsync.domain.run.service;
 
 import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.domain.run.dto.request.LocationUpdateReq;
+import com._s3k.runsync.domain.run.dto.request.RunRecordDetailReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionEndReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
 import com._s3k.runsync.domain.run.exception.RunSessionErrorCode;
@@ -35,6 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -141,8 +143,8 @@ class RunSessionServiceTest {
     void updateLocation_sessionNotOwner() {
         // given
         RunningSession session = mock(RunningSession.class);
-        given(session.getUserId()).willReturn(2L);
         given(runningSessionRepository.findById(1L)).willReturn(Optional.of(session));
+        doThrow(new GlobalException(RunSessionErrorCode.SESSION_NOT_OWNER)).when(session).validateOwner(1L);
 
         // when & then
         assertThatThrownBy(() -> runSessionService.updateLocation(1L, 1L, new LocationUpdateReq()))
@@ -156,9 +158,8 @@ class RunSessionServiceTest {
     void updateLocation_sessionNotActive() {
         // given
         RunningSession session = mock(RunningSession.class);
-        given(session.getUserId()).willReturn(1L);
-        given(session.getStatus()).willReturn(RunningSessionStatus.COMPLETED);
         given(runningSessionRepository.findById(1L)).willReturn(Optional.of(session));
+        doThrow(new GlobalException(RunSessionErrorCode.SESSION_NOT_ACTIVE)).when(session).validateActive();
 
         // when & then
         assertThatThrownBy(() -> runSessionService.updateLocation(1L, 1L, new LocationUpdateReq()))
@@ -179,8 +180,6 @@ class RunSessionServiceTest {
 
         User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
         RunningSession session = mock(RunningSession.class);
-        given(session.getUserId()).willReturn(userId);
-        given(session.getStatus()).willReturn(RunningSessionStatus.ACTIVE);
         given(session.createRecord(any())).willReturn(
                 RunRecord.of(user, session, 0, LocalDateTime.now(), BigDecimal.valueOf(5.0), null, null, null, null, null)
         );
@@ -211,8 +210,6 @@ class RunSessionServiceTest {
 
         User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
         RunningSession session = mock(RunningSession.class);
-        given(session.getUserId()).willReturn(userId);
-        given(session.getStatus()).willReturn(RunningSessionStatus.ACTIVE);
         given(session.createRecord(any())).willReturn(
                 RunRecord.of(user, session, 0, LocalDateTime.now(), BigDecimal.valueOf(5.0), null, null, null, null, null)
         );
@@ -256,8 +253,8 @@ class RunSessionServiceTest {
         ReflectionTestUtils.setField(request, "totalDistance", 5.0);
 
         RunningSession session = mock(RunningSession.class);
-        given(session.getUserId()).willReturn(2L);
         given(runningSessionRepository.findById(1L)).willReturn(Optional.of(session));
+        doThrow(new GlobalException(RunSessionErrorCode.SESSION_NOT_OWNER)).when(session).validateOwner(1L);
 
         // when & then
         assertThatThrownBy(() -> runSessionService.endRunSession(1L, 1L, request))
@@ -277,9 +274,8 @@ class RunSessionServiceTest {
         ReflectionTestUtils.setField(request, "totalDistance", 5.0);
 
         RunningSession session = mock(RunningSession.class);
-        given(session.getUserId()).willReturn(1L);
-        given(session.getStatus()).willReturn(RunningSessionStatus.COMPLETED);
         given(runningSessionRepository.findById(1L)).willReturn(Optional.of(session));
+        doThrow(new GlobalException(RunSessionErrorCode.SESSION_NOT_ACTIVE)).when(session).validateActive();
 
         // when & then
         assertThatThrownBy(() -> runSessionService.endRunSession(1L, 1L, request))
@@ -288,5 +284,88 @@ class RunSessionServiceTest {
                         .isEqualTo(RunSessionErrorCode.SESSION_NOT_ACTIVE));
 
         verify(runRecordRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("러닝 기록 세부 입력 저장 성공")
+    void saveRunRecordDetail_success() {
+        // given
+        Long userId = 1L;
+        Long sessionId = 1L;
+        RunRecordDetailReq request = new RunRecordDetailReq();
+        ReflectionTestUtils.setField(request, "averagePace", 6.43);
+        ReflectionTestUtils.setField(request, "calories", 450);
+
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession session = mock(RunningSession.class);
+        RunRecord record = RunRecord.of(user, session, 1800, LocalDateTime.now(), BigDecimal.valueOf(5.0), null, null, null, null, null);
+
+        given(runningSessionRepository.findById(sessionId)).willReturn(Optional.of(session));
+        given(runRecordRepository.findByRunningSessionId(sessionId)).willReturn(Optional.of(record));
+
+        // when
+        runSessionService.saveRunRecordDetail(userId, sessionId, request);
+
+        // then
+        verify(session).validateOwner(userId);
+        verify(session).validateCompleted();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 세션으로 기록 세부 입력 시 예외 발생")
+    void saveRunRecordDetail_sessionNotFound() {
+        // given
+        given(runningSessionRepository.findById(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.saveRunRecordDetail(1L, 1L, new RunRecordDetailReq()))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunSessionErrorCode.SESSION_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("다른 유저의 세션에 기록 세부 입력 시 예외 발생")
+    void saveRunRecordDetail_sessionNotOwner() {
+        // given
+        RunningSession session = mock(RunningSession.class);
+        given(runningSessionRepository.findById(1L)).willReturn(Optional.of(session));
+        doThrow(new GlobalException(RunSessionErrorCode.SESSION_NOT_OWNER)).when(session).validateOwner(1L);
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.saveRunRecordDetail(1L, 1L, new RunRecordDetailReq()))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunSessionErrorCode.SESSION_NOT_OWNER));
+    }
+
+    @Test
+    @DisplayName("완료되지 않은 세션에 기록 세부 입력 시 예외 발생")
+    void saveRunRecordDetail_sessionNotCompleted() {
+        // given
+        RunningSession session = mock(RunningSession.class);
+        given(runningSessionRepository.findById(1L)).willReturn(Optional.of(session));
+        doThrow(new GlobalException(RunSessionErrorCode.SESSION_NOT_COMPLETED)).when(session).validateCompleted();
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.saveRunRecordDetail(1L, 1L, new RunRecordDetailReq()))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunSessionErrorCode.SESSION_NOT_COMPLETED));
+    }
+
+    @Test
+    @DisplayName("런 레코드가 없는 세션에 기록 세부 입력 시 예외 발생")
+    void saveRunRecordDetail_runRecordNotFound() {
+        // given
+        RunningSession session = mock(RunningSession.class);
+        given(runningSessionRepository.findById(1L)).willReturn(Optional.of(session));
+        given(runRecordRepository.findByRunningSessionId(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.saveRunRecordDetail(1L, 1L, new RunRecordDetailReq()))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunSessionErrorCode.RUN_RECORD_NOT_FOUND));
     }
 }

--- a/src/test/java/com/_s3k/runsync/entity/RunningSessionTest.java
+++ b/src/test/java/com/_s3k/runsync/entity/RunningSessionTest.java
@@ -1,14 +1,18 @@
 package com._s3k.runsync.entity;
 
+import com._s3k.runsync.domain.run.exception.RunSessionErrorCode;
 import com._s3k.runsync.entity.enums.Provider;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
+import com._s3k.runsync.global.exception.GlobalException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class RunningSessionTest {
 
@@ -104,5 +108,84 @@ class RunningSessionTest {
         assertThat(record.getDurationSeconds()).isEqualTo(600);
         assertThat(record.getStartTime()).isEqualTo(startTime);
         assertThat(record.getDistance()).isEqualByComparingTo(BigDecimal.valueOf(5.0));
+    }
+
+    @Test
+    @DisplayName("validateOwner - 소유자가 맞으면 예외 없이 통과한다")
+    void validateOwner_success() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession session = RunningSession.of(user, LocalDateTime.now());
+        ReflectionTestUtils.setField(session, "userId", 1L);
+
+        // when & then
+        session.validateOwner(1L);
+    }
+
+    @Test
+    @DisplayName("validateOwner - 다른 유저면 SESSION_NOT_OWNER 예외 발생")
+    void validateOwner_notOwner() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession session = RunningSession.of(user, LocalDateTime.now());
+        ReflectionTestUtils.setField(session, "userId", 1L);
+
+        // when & then
+        assertThatThrownBy(() -> session.validateOwner(2L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunSessionErrorCode.SESSION_NOT_OWNER));
+    }
+
+    @Test
+    @DisplayName("validateActive - ACTIVE 상태면 예외 없이 통과한다")
+    void validateActive_success() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession session = RunningSession.of(user, LocalDateTime.now());
+
+        // when & then
+        session.validateActive();
+    }
+
+    @Test
+    @DisplayName("validateActive - ACTIVE 아니면 SESSION_NOT_ACTIVE 예외 발생")
+    void validateActive_notActive() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession session = RunningSession.of(user, LocalDateTime.now());
+        session.complete(LocalDateTime.now().plusMinutes(30), BigDecimal.valueOf(5.0));
+
+        // when & then
+        assertThatThrownBy(session::validateActive)
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunSessionErrorCode.SESSION_NOT_ACTIVE));
+    }
+
+    @Test
+    @DisplayName("validateCompleted - COMPLETED 상태면 예외 없이 통과한다")
+    void validateCompleted_success() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession session = RunningSession.of(user, LocalDateTime.now());
+        session.complete(LocalDateTime.now().plusMinutes(30), BigDecimal.valueOf(5.0));
+
+        // when & then
+        session.validateCompleted();
+    }
+
+    @Test
+    @DisplayName("validateCompleted - COMPLETED 아니면 SESSION_NOT_COMPLETED 예외 발생")
+    void validateCompleted_notCompleted() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession session = RunningSession.of(user, LocalDateTime.now());
+
+        // when & then
+        assertThatThrownBy(session::validateCompleted)
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunSessionErrorCode.SESSION_NOT_COMPLETED));
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #19 

## 📝작업 내용
- POST /api/run-sessions/{sessionId}/records 엔드포인트 추가
- 요청 필드(평균 페이스, 소모 칼로리, 평균 심박수, 케이던스, 고도 상승) 모두 선택값으로 처리
- 세션 소유자 검증 / COMPLETED 상태 검증 후 기록 업데이트
- RunningSession에 validateOwner(), validateActive(), validateCompleted() 추가 — 서비스 전반의 검증 로직 엔티티로 이동
- RunningSessionTest, RunSessionServiceTest 테스트 추가 및 수정

## 📷스크린샷 (선택)
<img width="1437" height="791" alt="스크린샷 2026-05-18 오전 11 26 44" src="https://github.com/user-attachments/assets/f41c6397-2d88-481c-995e-d4ca615467f3" />
<img width="1409" height="542" alt="스크린샷 2026-05-18 오전 11 26 54" src="https://github.com/user-attachments/assets/cf7bc1ef-13f9-470f-9ce7-29f5fed4a56f" />
<img width="1140" height="736" alt="스크린샷 2026-05-18 오전 11 28 50" src="https://github.com/user-attachments/assets/f98d639c-c92a-4dcf-8042-f236be3a7d2d" />
