### PR TITLE
[Feat] 러닝 기록 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/run/controller/RunRecordController.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/controller/RunRecordController.java
@@ -1,0 +1,29 @@
+package com._s3k.runsync.domain.run.controller;
+
+import com._s3k.runsync.domain.run.dto.response.RunRecordRes;
+import com._s3k.runsync.domain.run.service.RunRecordService;
+import com._s3k.runsync.global.common.dto.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/run-records")
+@RequiredArgsConstructor
+public class RunRecordController {
+
+    private final RunRecordService runRecordService;
+
+    @GetMapping("/{recordId}")
+    @Operation(summary = "러닝 기록 상세 조회", description = "러닝 기록 상세 정보를 조회합니다. 로그인 필요")
+    public CommonResponse<RunRecordRes> getRunRecord(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long recordId
+    ) {
+        return CommonResponse.success(runRecordService.getRunRecordById(userId, recordId));
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunRecordDetailReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunRecordDetailReq.java
@@ -1,5 +1,6 @@
 package com._s3k.runsync.domain.run.dto.request;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.Digits;
 import jakarta.validation.constraints.PositiveOrZero;
@@ -35,11 +36,11 @@ public class RunRecordDetailReq {
     @Schema(description = "고도 상승(m)", example = "5.0")
     private Double elevationGain;
 
-    public BigDecimal getAveragePaceAsBigDecimal() {
+    public BigDecimal toAveragePaceBigDecimal() {
         return averagePace != null ? BigDecimal.valueOf(averagePace) : null;
     }
 
-    public BigDecimal getElevationGainAsBigDecimal() {
+    public BigDecimal toElevationGainBigDecimal() {
         return elevationGain != null ? BigDecimal.valueOf(elevationGain) : null;
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunPathRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunPathRes.java
@@ -1,0 +1,51 @@
+package com._s3k.runsync.domain.run.dto.response;
+
+import com._s3k.runsync.entity.RunPath;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Schema(description = "GPS 경로 포인트")
+public class RunPathRes {
+
+    @Schema(description = "좌표 순서", example = "1")
+    private final Integer sequence;
+
+    @Schema(description = "위도", example = "37.1234")
+    private final Double latitude;
+
+    @Schema(description = "경도", example = "127.5678")
+    private final Double longitude;
+
+    @Schema(description = "기록 시간", example = "2026-03-01T09:00:05")
+    private final LocalDateTime recordedAt;
+
+    @Schema(description = "속도 (km/h)", example = "8.50")
+    private final Double speedKmh;
+
+    @Schema(description = "페이스 (분/km)", example = "7.05")
+    private final Double paceMinPerKm;
+
+    private RunPathRes(Integer sequence, Double latitude, Double longitude, LocalDateTime recordedAt,
+                       Double speedKmh, Double paceMinPerKm) {
+        this.sequence = sequence;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.recordedAt = recordedAt;
+        this.speedKmh = speedKmh;
+        this.paceMinPerKm = paceMinPerKm;
+    }
+
+    public static RunPathRes of(RunPath path) {
+        return new RunPathRes(
+                path.getSequence(),
+                path.getLocation().getY(),
+                path.getLocation().getX(),
+                path.getRecordedAt(),
+                path.getSpeedKmh() != null ? path.getSpeedKmh().doubleValue() : null,
+                path.getPaceMinPerKm() != null ? path.getPaceMinPerKm().doubleValue() : null
+        );
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunRecordRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunRecordRes.java
@@ -1,0 +1,73 @@
+package com._s3k.runsync.domain.run.dto.response;
+
+import com._s3k.runsync.entity.RunRecord;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Schema(description = "러닝 기록 상세 응답")
+public class RunRecordRes {
+
+    @Schema(description = "기록 ID", example = "1")
+    private final Long recordId;
+
+    @Schema(description = "러닝 시작 시간", example = "2026-03-01T09:00:00")
+    private final LocalDateTime startTime;
+
+    @Schema(description = "소요 시간 (초)", example = "1048")
+    private final Integer durationSeconds;
+
+    @Schema(description = "이동 거리 (km)", example = "5.20")
+    private final Double distance;
+
+    @Schema(description = "평균 페이스 (min/km)", example = "6.43")
+    private final Double averagePace;
+
+    @Schema(description = "소모 칼로리 (kcal)", example = "134")
+    private final Integer calories;
+
+    @Schema(description = "케이던스 (spm)", example = "167")
+    private final Integer cadence;
+
+    @Schema(description = "고도 상승 (m)", example = "12.50")
+    private final Double elevationGain;
+
+    @Schema(description = "평균 심박수 (bpm)", example = "172")
+    private final Integer averageHeartRate;
+
+    @Schema(description = "GPS 경로 포인트 배열, 경로 없는 경우 빈 배열")
+    private final List<RunPathRes> paths;
+
+    private RunRecordRes(Long recordId, LocalDateTime startTime, Integer durationSeconds,
+                         Double distance, Double averagePace, Integer calories, Integer cadence,
+                         Double elevationGain, Integer averageHeartRate, List<RunPathRes> paths) {
+        this.recordId = recordId;
+        this.startTime = startTime;
+        this.durationSeconds = durationSeconds;
+        this.distance = distance;
+        this.averagePace = averagePace;
+        this.calories = calories;
+        this.cadence = cadence;
+        this.elevationGain = elevationGain;
+        this.averageHeartRate = averageHeartRate;
+        this.paths = paths;
+    }
+
+    public static RunRecordRes of(RunRecord record) {
+        return new RunRecordRes(
+                record.getId(),
+                record.getStartTime(),
+                record.getDurationSeconds(),
+                record.getDistance().doubleValue(),
+                record.getAveragePace() != null ? record.getAveragePace().doubleValue() : null,
+                record.getCalories(),
+                record.getCadence(),
+                record.getElevationGain() != null ? record.getElevationGain().doubleValue() : null,
+                record.getAverageHeartRate(),
+                record.getPaths().stream().map(RunPathRes::of).toList()
+        );
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/exception/RunRecordErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/exception/RunRecordErrorCode.java
@@ -1,0 +1,18 @@
+package com._s3k.runsync.domain.run.exception;
+
+import com._s3k.runsync.global.exception.ResultCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum RunRecordErrorCode implements ResultCode {
+
+    RECORD_NOT_FOUND(HttpStatus.NOT_FOUND, 4001, "러닝 기록을 찾을 수 없습니다."),
+    RECORD_NOT_OWNER(HttpStatus.FORBIDDEN, 4002, "해당 러닝 기록에 대한 권한이 없습니다.");
+
+    private final HttpStatus status;
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
@@ -11,6 +11,6 @@ public interface RunRecordRepository extends JpaRepository<RunRecord, Long> {
 
     Optional<RunRecord> findByRunningSessionId(Long sessionId);
 
-    @Query("SELECT r FROM RunRecord r LEFT JOIN FETCH r.paths p WHERE r.id = :recordId ORDER BY p.sequence ASC")
+    @Query("SELECT r FROM RunRecord r LEFT JOIN FETCH r.paths WHERE r.id = :recordId")
     Optional<RunRecord> findByIdWithPaths(@Param("recordId") Long recordId);
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
@@ -2,10 +2,15 @@ package com._s3k.runsync.domain.run.repository;
 
 import com._s3k.runsync.entity.RunRecord;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface RunRecordRepository extends JpaRepository<RunRecord, Long> {
 
     Optional<RunRecord> findByRunningSessionId(Long sessionId);
+
+    @Query("SELECT r FROM RunRecord r LEFT JOIN FETCH r.paths p WHERE r.id = :recordId ORDER BY p.sequence ASC")
+    Optional<RunRecord> findByIdWithPaths(@Param("recordId") Long recordId);
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/service/RunRecordService.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/service/RunRecordService.java
@@ -1,0 +1,27 @@
+package com._s3k.runsync.domain.run.service;
+
+import com._s3k.runsync.domain.run.dto.response.RunRecordRes;
+import com._s3k.runsync.domain.run.exception.RunRecordErrorCode;
+import com._s3k.runsync.domain.run.repository.RunRecordRepository;
+import com._s3k.runsync.entity.RunRecord;
+import com._s3k.runsync.global.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class RunRecordService {
+
+    private final RunRecordRepository runRecordRepository;
+
+    @Transactional(readOnly = true)
+    public RunRecordRes getRunRecordById(Long userId, Long recordId) {
+        RunRecord record = runRecordRepository.findByIdWithPaths(recordId)
+                .orElseThrow(() -> new GlobalException(RunRecordErrorCode.RECORD_NOT_FOUND));
+
+        record.validateOwner(userId);
+
+        return RunRecordRes.of(record);
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
@@ -146,9 +146,13 @@ public class RunSessionService {
                 LocalDateTime recordedAt = LocalDateTime.ofInstant(
                         Instant.parse((String) pathData.get("recordedAt")), ZoneOffset.UTC);
                 BigDecimal speedKmh = BigDecimal.valueOf(speed * 3.6).setScale(2, RoundingMode.HALF_UP);
-                BigDecimal paceMinPerKm = speed > 0
-                        ? BigDecimal.valueOf(1000.0 / (speed * 60)).setScale(2, RoundingMode.HALF_UP)
-                        : null;
+                BigDecimal paceMinPerKm = null;
+                if (speed > 0) {
+                    double rawPace = 1000.0 / (speed * 60);
+                    if (rawPace <= 999.99) {
+                        paceMinPerKm = BigDecimal.valueOf(rawPace).setScale(2, RoundingMode.HALF_UP);
+                    }
+                }
 
                 paths.add(RunPath.of(runRecord, lat, lng, i + 1, recordedAt, speedKmh, paceMinPerKm));
             } catch (Exception e) {

--- a/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
@@ -82,11 +82,11 @@ public class RunSessionService {
                 .orElseThrow(() -> new GlobalException(RunSessionErrorCode.RUN_RECORD_NOT_FOUND));
 
         record.updateDetails(
-                request.getAveragePaceAsBigDecimal(),
+                request.toAveragePaceBigDecimal(),
                 request.getCalories(),
                 request.getAverageHeartRate(),
                 request.getCadence(),
-                request.getElevationGainAsBigDecimal()
+                request.toElevationGainBigDecimal()
         );
 
         return RunRecordDetailRes.of(record);
@@ -146,8 +146,11 @@ public class RunSessionService {
                 LocalDateTime recordedAt = LocalDateTime.ofInstant(
                         Instant.parse((String) pathData.get("recordedAt")), ZoneOffset.UTC);
                 BigDecimal speedKmh = BigDecimal.valueOf(speed * 3.6).setScale(2, RoundingMode.HALF_UP);
+                BigDecimal paceMinPerKm = speed > 0
+                        ? BigDecimal.valueOf(1000.0 / (speed * 60)).setScale(2, RoundingMode.HALF_UP)
+                        : null;
 
-                paths.add(RunPath.of(runRecord, lat, lng, i + 1, recordedAt, null, speedKmh, null, null));
+                paths.add(RunPath.of(runRecord, lat, lng, i + 1, recordedAt, speedKmh, paceMinPerKm));
             } catch (Exception e) {
                 throw new GlobalException(RunSessionErrorCode.PATH_PARSE_FAILED);
             }

--- a/src/main/java/com/_s3k/runsync/entity/RunPath.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunPath.java
@@ -36,43 +36,32 @@ public class RunPath extends BaseEntity {
     @Column(name = "recorded_at", nullable = false)
     private LocalDateTime recordedAt;
 
-    @Column(name = "altitude_m", precision = 7, scale = 2)
-    private BigDecimal altitudeM;
-
     @Column(name = "speed_kmh", precision = 5, scale = 2)
     private BigDecimal speedKmh;
 
     @Column(name = "pace_min_per_km", precision = 5, scale = 2)
     private BigDecimal paceMinPerKm;
 
-    @Column(name = "accuracy_m", precision = 6, scale = 2)
-    private BigDecimal accuracyM;
-
     @Builder(access = AccessLevel.PRIVATE)
     private RunPath(RunRecord runRecord, Point location, Integer sequence, LocalDateTime recordedAt,
-                    BigDecimal altitudeM, BigDecimal speedKmh, BigDecimal paceMinPerKm, BigDecimal accuracyM) {
+                    BigDecimal speedKmh, BigDecimal paceMinPerKm) {
         this.runRecord = runRecord;
         this.location = location;
         this.sequence = sequence;
         this.recordedAt = recordedAt;
-        this.altitudeM = altitudeM;
         this.speedKmh = speedKmh;
         this.paceMinPerKm = paceMinPerKm;
-        this.accuracyM = accuracyM;
     }
 
     public static RunPath of(RunRecord runRecord, double latitude, double longitude, Integer sequence,
-                             LocalDateTime recordedAt, BigDecimal altitudeM, BigDecimal speedKmh,
-                             BigDecimal paceMinPerKm, BigDecimal accuracyM) {
+                             LocalDateTime recordedAt, BigDecimal speedKmh, BigDecimal paceMinPerKm) {
         return RunPath.builder()
                 .runRecord(runRecord)
                 .location(GEOMETRY_FACTORY.createPoint(new Coordinate(longitude, latitude)))
                 .sequence(sequence)
                 .recordedAt(recordedAt)
-                .altitudeM(altitudeM)
                 .speedKmh(speedKmh)
                 .paceMinPerKm(paceMinPerKm)
-                .accuracyM(accuracyM)
                 .build();
     }
 }

--- a/src/main/java/com/_s3k/runsync/entity/RunRecord.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunRecord.java
@@ -56,6 +56,7 @@ public class RunRecord extends BaseEntity {
     @Column(name = "cadence")
     private Integer cadence;
 
+    @OrderBy("sequence ASC")
     @OneToMany(mappedBy = "runRecord", cascade = CascadeType.PERSIST)
     private List<RunPath> paths = new ArrayList<>();
 

--- a/src/main/java/com/_s3k/runsync/entity/RunRecord.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunRecord.java
@@ -1,10 +1,14 @@
 package com._s3k.runsync.entity;
 
+import com._s3k.runsync.domain.run.exception.RunRecordErrorCode;
+import com._s3k.runsync.global.exception.GlobalException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.Objects;
 
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
@@ -21,6 +25,9 @@ public class RunRecord extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
+    @Column(name = "user_id", insertable = false, updatable = false)
+    private Long userId;
+
     @OneToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "running_session_id")
     private RunningSession runningSession;
@@ -31,7 +38,7 @@ public class RunRecord extends BaseEntity {
     @Column(name = "start_time", nullable = false)
     private LocalDateTime startTime;
 
-    @Column(name = "distance", precision = 5, scale = 2)
+    @Column(name = "distance", precision = 5, scale = 2, nullable = false)
     private BigDecimal distance;
 
     @Column(name = "average_pace", precision = 5, scale = 2)
@@ -68,6 +75,12 @@ public class RunRecord extends BaseEntity {
         this.averageHeartRate = averageHeartRate;
         this.cadence = cadence;
         this.paths = new ArrayList<>();
+    }
+
+    public void validateOwner(Long userId) {
+        if (!Objects.equals(this.userId, userId)) {
+            throw new GlobalException(RunRecordErrorCode.RECORD_NOT_OWNER);
+        }
     }
 
     public void addPaths(List<RunPath> runPaths) {

--- a/src/test/java/com/_s3k/runsync/domain/run/service/RunRecordServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/run/service/RunRecordServiceTest.java
@@ -1,0 +1,84 @@
+package com._s3k.runsync.domain.run.service;
+
+import com._s3k.runsync.domain.run.exception.RunRecordErrorCode;
+import com._s3k.runsync.domain.run.repository.RunRecordRepository;
+import com._s3k.runsync.entity.RunRecord;
+import com._s3k.runsync.global.exception.GlobalException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class RunRecordServiceTest {
+
+    @InjectMocks
+    private RunRecordService runRecordService;
+
+    @Mock
+    private RunRecordRepository runRecordRepository;
+
+    @Test
+    @DisplayName("러닝 기록 상세 조회 성공")
+    void getRunRecordById_success() {
+        // given
+        Long userId = 1L;
+        Long recordId = 1L;
+
+        RunRecord record = mock(RunRecord.class);
+        given(record.getId()).willReturn(recordId);
+        given(record.getStartTime()).willReturn(LocalDateTime.now());
+        given(record.getDurationSeconds()).willReturn(1800);
+        given(record.getDistance()).willReturn(BigDecimal.valueOf(5.0));
+        given(record.getPaths()).willReturn(List.of());
+        given(runRecordRepository.findByIdWithPaths(recordId)).willReturn(Optional.of(record));
+
+        // when
+        var result = runRecordService.getRunRecordById(userId, recordId);
+
+        // then
+        assertThat(result.getRecordId()).isEqualTo(recordId);
+        assertThat(result.getPaths()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 기록 조회 시 예외 발생")
+    void getRunRecordById_recordNotFound() {
+        // given
+        given(runRecordRepository.findByIdWithPaths(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> runRecordService.getRunRecordById(1L, 1L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunRecordErrorCode.RECORD_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("다른 유저의 기록 조회 시 예외 발생")
+    void getRunRecordById_notOwner() {
+        // given
+        RunRecord record = mock(RunRecord.class);
+        given(runRecordRepository.findByIdWithPaths(1L)).willReturn(Optional.of(record));
+        doThrow(new GlobalException(RunRecordErrorCode.RECORD_NOT_OWNER)).when(record).validateOwner(1L);
+
+        // when & then
+        assertThatThrownBy(() -> runRecordService.getRunRecordById(1L, 1L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunRecordErrorCode.RECORD_NOT_OWNER));
+    }
+}

--- a/src/test/java/com/_s3k/runsync/entity/RunRecordTest.java
+++ b/src/test/java/com/_s3k/runsync/entity/RunRecordTest.java
@@ -1,0 +1,46 @@
+package com._s3k.runsync.entity;
+
+import com._s3k.runsync.domain.run.exception.RunRecordErrorCode;
+import com._s3k.runsync.entity.enums.Provider;
+import com._s3k.runsync.global.exception.GlobalException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class RunRecordTest {
+
+    @Test
+    @DisplayName("validateOwner - 소유자가 맞으면 예외 없이 통과한다")
+    void validateOwner_success() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunRecord record = RunRecord.of(user, null, 1800, LocalDateTime.now(),
+                BigDecimal.valueOf(5.0), null, null, null, null, null);
+        ReflectionTestUtils.setField(record, "userId", 1L);
+
+        // when & then
+        record.validateOwner(1L);
+    }
+
+    @Test
+    @DisplayName("validateOwner - 다른 유저면 RECORD_NOT_OWNER 예외 발생")
+    void validateOwner_notOwner() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunRecord record = RunRecord.of(user, null, 1800, LocalDateTime.now(),
+                BigDecimal.valueOf(5.0), null, null, null, null, null);
+        ReflectionTestUtils.setField(record, "userId", 1L);
+
+        // when & then
+        assertThatThrownBy(() -> record.validateOwner(2L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(RunRecordErrorCode.RECORD_NOT_OWNER));
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #21 

## 📝작업 내용

- GET /api/run-records/{recordId} 엔드포인트 구현
- 소유자 검증 후 러닝 기록 및 GPS 경로 포인트 상세 조회
- RunRecord에 validateOwner() 추가 (RunningSession과 일관성 맞춤)
- JOIN FETCH로 paths 한 번에 조회 (N+1 방지)
- RunPath에서 불필요한 필드 제거 (altitudeM, accuracyM)
- paceMinPerKm 서버 계산 추가 (speed m/s → 분/km 변환)
 
## 📷스크린샷 (선택)
<img width="1445" height="729" alt="스크린샷 2026-05-18 오후 4 48 04" src="https://github.com/user-attachments/assets/97f6176e-e936-4f46-9dcb-2c81054c9edf" />
<img width="1454" height="794" alt="스크린샷 2026-05-18 오후 4 48 17" src="https://github.com/user-attachments/assets/61778bb2-4379-4309-9e61-270718863566" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?