### PR TITLE
[Feat] 친구 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
@@ -1,0 +1,27 @@
+package com._s3k.runsync.domain.friend.controller;
+
+import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
+import com._s3k.runsync.domain.friend.service.FriendService;
+import com._s3k.runsync.global.common.dto.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import java.util.List;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/friends")
+@RequiredArgsConstructor
+public class FriendController {
+
+    private final FriendService friendService;
+
+    @Operation(summary = "친구 목록 조회", description = "친구 목록 및 활동 상태 조회. 로그인 필요")
+    @GetMapping
+    public CommonResponse<List<FriendListRes>> getFriends(
+            @AuthenticationPrincipal Long userId) {
+        return CommonResponse.success(friendService.getFriendsByUserId(userId));
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/friend/dto/response/FriendListRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/dto/response/FriendListRes.java
@@ -1,7 +1,7 @@
 package com._s3k.runsync.domain.friend.dto.response;
 
 import com._s3k.runsync.entity.User;
-import com._s3k.runsync.entity.enums.FriendStatus;
+import com._s3k.runsync.entity.enums.ActivityStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -26,7 +26,7 @@ public class FriendListRes {
     @Schema(description = "마지막 활동 시간. OFFLINE 상태에서는 마지막 러닝 종료 시각, RUNNING 상태에서는 null", example = "2026-04-10T15:00:00")
     private LocalDateTime lastActiveAt;
 
-    private FriendListRes(User friend, FriendStatus status, LocalDateTime lastActiveAt) {
+    private FriendListRes(User friend, ActivityStatus status, LocalDateTime lastActiveAt) {
         this.friendUserId = friend.getId();
         this.nickname = friend.getNickname();
         this.profileImage = friend.getProfileImage();
@@ -34,7 +34,7 @@ public class FriendListRes {
         this.lastActiveAt = lastActiveAt;
     }
 
-    public static FriendListRes of(User friend, FriendStatus status, LocalDateTime lastActiveAt) {
+    public static FriendListRes of(User friend, ActivityStatus status, LocalDateTime lastActiveAt) {
         return new FriendListRes(friend, status, lastActiveAt);
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/friend/dto/response/FriendListRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/dto/response/FriendListRes.java
@@ -1,0 +1,40 @@
+package com._s3k.runsync.domain.friend.dto.response;
+
+import com._s3k.runsync.entity.User;
+import com._s3k.runsync.entity.enums.FriendStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Schema(description = "친구 목록 응답")
+public class FriendListRes {
+
+    @Schema(description = "친구 사용자 ID", example = "2")
+    private Long friendUserId;
+
+    @Schema(description = "친구 닉네임", example = "한현우")
+    private String nickname;
+
+    @Schema(description = "친구 프로필 이미지", example = "https://...")
+    private String profileImage;
+
+    @Schema(description = "활동 상태 (RUNNING / OFFLINE)", example = "RUNNING")
+    private String activityStatus;
+
+    @Schema(description = "마지막 활동 시간. OFFLINE 상태에서는 마지막 러닝 종료 시각, RUNNING 상태에서는 null", example = "2026-04-10T15:00:00")
+    private LocalDateTime lastActiveAt;
+
+    private FriendListRes(User friend, FriendStatus status, LocalDateTime lastActiveAt) {
+        this.friendUserId = friend.getId();
+        this.nickname = friend.getNickname();
+        this.profileImage = friend.getProfileImage();
+        this.activityStatus = status.name();
+        this.lastActiveAt = lastActiveAt;
+    }
+
+    public static FriendListRes of(User friend, FriendStatus status, LocalDateTime lastActiveAt) {
+        return new FriendListRes(friend, status, lastActiveAt);
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendshipRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendshipRepository.java
@@ -1,0 +1,15 @@
+package com._s3k.runsync.domain.friend.repository;
+
+import com._s3k.runsync.entity.Friendship;
+import com._s3k.runsync.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
+
+    @Query("SELECT f.friend FROM Friendship f WHERE f.user.id = :userId AND f.friend.isDeleted = false")
+    List<User> findFriendsByUserId(@Param("userId") Long userId);
+}

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -1,0 +1,67 @@
+package com._s3k.runsync.domain.friend.service;
+
+import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
+import com._s3k.runsync.domain.friend.repository.FriendshipRepository;
+import com._s3k.runsync.domain.run.repository.RunRecordRepository;
+import com._s3k.runsync.domain.run.repository.RunningSessionRepository;
+import com._s3k.runsync.entity.RunRecord;
+import com._s3k.runsync.entity.RunningSession;
+import com._s3k.runsync.entity.User;
+import com._s3k.runsync.entity.enums.FriendStatus;
+import com._s3k.runsync.entity.enums.RunningSessionStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class FriendService {
+
+    private final FriendshipRepository friendshipRepository;
+    private final RunningSessionRepository runningSessionRepository;
+    private final RunRecordRepository runRecordRepository;
+
+    @Transactional(readOnly = true)
+    public List<FriendListRes> getFriendsByUserId(Long userId) {
+        List<User> friends = friendshipRepository.findFriendsByUserId(userId);
+        if (friends.isEmpty()) return Collections.emptyList();
+
+        List<Long> friendIds = friends.stream().map(User::getId).toList();
+
+        Map<Long, RunningSession> activeSessionMap = runningSessionRepository
+                .findByUserIdInAndStatus(friendIds, RunningSessionStatus.ACTIVE)
+                .stream()
+                .collect(Collectors.toMap(
+                        RunningSession::getUserId,
+                        Function.identity(),
+                        (a, b) -> a.getStartTime().isAfter(b.getStartTime()) ? a : b
+                ));
+
+        Map<Long, RunRecord> lastRecordMap = runRecordRepository
+                .findLatestByUserIds(friendIds)
+                .stream()
+                .collect(Collectors.toMap(
+                        RunRecord::getUserId,
+                        Function.identity(),
+                        (a, b) -> a.getId().compareTo(b.getId()) > 0 ? a : b
+                ));
+
+        return friends.stream()
+                .map(friend -> {
+                    RunningSession activeSession = activeSessionMap.get(friend.getId());
+                    if (activeSession != null) {
+                        return FriendListRes.of(friend, FriendStatus.RUNNING, null);
+                    }
+                    RunRecord lastRecord = lastRecordMap.get(friend.getId());
+                    return FriendListRes.of(friend, FriendStatus.OFFLINE,
+                            lastRecord != null ? lastRecord.getLastActiveAt() : null);
+                })
+                .toList();
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -7,13 +7,15 @@ import com._s3k.runsync.domain.run.repository.RunningSessionRepository;
 import com._s3k.runsync.entity.RunRecord;
 import com._s3k.runsync.entity.RunningSession;
 import com._s3k.runsync.entity.User;
-import com._s3k.runsync.entity.enums.FriendStatus;
+import com._s3k.runsync.entity.enums.ActivityStatus;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDateTime;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
@@ -52,16 +54,23 @@ public class FriendService {
                         (a, b) -> a.getId().compareTo(b.getId()) > 0 ? a : b
                 ));
 
+        record FriendInfo(User friend, ActivityStatus status, LocalDateTime lastActiveAt) {}
+
         return friends.stream()
                 .map(friend -> {
                     RunningSession activeSession = activeSessionMap.get(friend.getId());
                     if (activeSession != null) {
-                        return FriendListRes.of(friend, FriendStatus.RUNNING, null);
+                        return new FriendInfo(friend, ActivityStatus.RUNNING, null);
                     }
                     RunRecord lastRecord = lastRecordMap.get(friend.getId());
-                    return FriendListRes.of(friend, FriendStatus.OFFLINE,
+                    return new FriendInfo(friend, ActivityStatus.OFFLINE,
                             lastRecord != null ? lastRecord.getLastActiveAt() : null);
                 })
+                .sorted(Comparator
+                        .comparing(FriendInfo::status)
+                        .thenComparing(FriendInfo::lastActiveAt, Comparator.nullsLast(Comparator.reverseOrder()))
+                        .thenComparing(info -> info.friend().getId()))
+                .map(info -> FriendListRes.of(info.friend(), info.status(), info.lastActiveAt()))
                 .toList();
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/location/dto/response/ActivityStatusRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/dto/response/ActivityStatusRes.java
@@ -1,25 +1,25 @@
 package com._s3k.runsync.domain.location.dto.response;
 
-import com._s3k.runsync.entity.enums.FriendStatus;
+import com._s3k.runsync.entity.enums.ActivityStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 @Schema(description = "친구 상태 응답")
-public class FriendStatusRes {
+public class ActivityStatusRes {
 
     @Schema(description = "친구 유저 ID", example = "2")
     private final Long friendId;
 
     @Schema(description = "상태", example = "RUNNING")
-    private final FriendStatus status;
+    private final ActivityStatus status;
 
-    private FriendStatusRes(Long friendId, FriendStatus status) {
+    private ActivityStatusRes(Long friendId, ActivityStatus status) {
         this.friendId = friendId;
         this.status = status;
     }
 
-    public static FriendStatusRes of(Long friendId, FriendStatus status) {
-        return new FriendStatusRes(friendId, status);
+    public static ActivityStatusRes of(Long friendId, ActivityStatus status) {
+        return new ActivityStatusRes(friendId, status);
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/location/handler/WebSocketEventListener.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/handler/WebSocketEventListener.java
@@ -1,8 +1,8 @@
 package com._s3k.runsync.domain.location.handler;
 
-import com._s3k.runsync.domain.location.dto.response.FriendStatusRes;
+import com._s3k.runsync.domain.location.dto.response.ActivityStatusRes;
 import com._s3k.runsync.domain.location.service.LocationService;
-import com._s3k.runsync.entity.enums.FriendStatus;
+import com._s3k.runsync.entity.enums.ActivityStatus;
 import com._s3k.runsync.global.websocket.dto.WebSocketMessage;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -31,7 +31,7 @@ public class WebSocketEventListener {
         if (principal == null) return;
 
         Long userId = Long.parseLong(principal.getName());
-        notifyFriends(userId, FriendStatus.RUNNING);
+        notifyFriends(userId, ActivityStatus.RUNNING);
     }
 
     @EventListener
@@ -42,10 +42,10 @@ public class WebSocketEventListener {
 
         Long userId = Long.parseLong(principal.getName());
         locationService.removeLocation(userId);
-        notifyFriends(userId, FriendStatus.OFFLINE);
+        notifyFriends(userId, ActivityStatus.OFFLINE);
     }
 
-    private void notifyFriends(Long userId, FriendStatus status) {
+    private void notifyFriends(Long userId, ActivityStatus status) {
         Set<String> friendIds;
         try {
             friendIds = locationService.getFriendIds(userId);
@@ -56,7 +56,7 @@ public class WebSocketEventListener {
         }
         if (friendIds == null || friendIds.isEmpty()) return;
 
-        FriendStatusRes statusData = FriendStatusRes.of(userId, status);
+        ActivityStatusRes statusData = ActivityStatusRes.of(userId, status);
 
         for (String friendId : friendIds) {
             messagingTemplate.convertAndSendToUser(

--- a/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
@@ -17,8 +17,8 @@ public interface RunRecordRepository extends JpaRepository<RunRecord, Long> {
 
     @Query("""
             SELECT r FROM RunRecord r
-            WHERE r.userId IN :userIds
-            AND r.startTime = (SELECT MAX(r2.startTime) FROM RunRecord r2 WHERE r2.userId = r.userId)
+            WHERE r.user.id IN :userIds
+            AND r.startTime = (SELECT MAX(r2.startTime) FROM RunRecord r2 WHERE r2.user.id = r.user.id)
             """)
     List<RunRecord> findLatestByUserIds(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
@@ -5,6 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface RunRecordRepository extends JpaRepository<RunRecord, Long> {
@@ -13,4 +14,11 @@ public interface RunRecordRepository extends JpaRepository<RunRecord, Long> {
 
     @Query("SELECT r FROM RunRecord r LEFT JOIN FETCH r.paths WHERE r.id = :recordId")
     Optional<RunRecord> findByIdWithPaths(@Param("recordId") Long recordId);
+
+    @Query("""
+            SELECT r FROM RunRecord r
+            WHERE r.userId IN :userIds
+            AND r.startTime = (SELECT MAX(r2.startTime) FROM RunRecord r2 WHERE r2.userId = r.userId)
+            """)
+    List<RunRecord> findLatestByUserIds(@Param("userIds") List<Long> userIds);
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/repository/RunningSessionRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/RunningSessionRepository.java
@@ -4,7 +4,14 @@ import com._s3k.runsync.entity.RunningSession;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface RunningSessionRepository extends JpaRepository<RunningSession, Long> {
 
     boolean existsByUserIdAndStatus(Long userId, RunningSessionStatus status);
+
+    Optional<RunningSession> findByUserIdAndStatus(Long userId, RunningSessionStatus status);
+
+    List<RunningSession> findByUserIdInAndStatus(List<Long> userIds, RunningSessionStatus status);
 }

--- a/src/main/java/com/_s3k/runsync/entity/RunRecord.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunRecord.java
@@ -78,6 +78,10 @@ public class RunRecord extends BaseEntity {
         this.paths = new ArrayList<>();
     }
 
+    public LocalDateTime getLastActiveAt() {
+        return this.startTime.plusSeconds(this.durationSeconds);
+    }
+
     public void validateOwner(Long userId) {
         if (!Objects.equals(this.userId, userId)) {
             throw new GlobalException(RunRecordErrorCode.RECORD_NOT_OWNER);

--- a/src/main/java/com/_s3k/runsync/entity/enums/ActivityStatus.java
+++ b/src/main/java/com/_s3k/runsync/entity/enums/ActivityStatus.java
@@ -1,6 +1,6 @@
 package com._s3k.runsync.entity.enums;
 
-public enum FriendStatus {
+public enum ActivityStatus {
     RUNNING,
     OFFLINE
 }

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -1,0 +1,123 @@
+package com._s3k.runsync.domain.friend.service;
+
+import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
+import com._s3k.runsync.domain.friend.repository.FriendshipRepository;
+import com._s3k.runsync.domain.run.repository.RunRecordRepository;
+import com._s3k.runsync.domain.run.repository.RunningSessionRepository;
+import com._s3k.runsync.entity.RunRecord;
+import com._s3k.runsync.entity.RunningSession;
+import com._s3k.runsync.entity.User;
+import com._s3k.runsync.entity.enums.FriendStatus;
+import com._s3k.runsync.entity.enums.RunningSessionStatus;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class FriendServiceTest {
+
+    @InjectMocks
+    private FriendService friendService;
+
+    @Mock
+    private FriendshipRepository friendshipRepository;
+
+    @Mock
+    private RunningSessionRepository runningSessionRepository;
+
+    @Mock
+    private RunRecordRepository runRecordRepository;
+
+    @Test
+    @DisplayName("친구가 없으면 빈 리스트 반환")
+    void getFriendsByUserId_noFriends() {
+        // given
+        given(friendshipRepository.findFriendsByUserId(1L)).willReturn(List.of());
+
+        // when
+        List<FriendListRes> result = friendService.getFriendsByUserId(1L);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("ACTIVE 세션이 있는 친구는 RUNNING 상태, lastActiveAt은 null")
+    void getFriendsByUserId_running() {
+        // given
+        User friend = mock(User.class);
+        given(friend.getId()).willReturn(2L);
+        given(friendshipRepository.findFriendsByUserId(1L)).willReturn(List.of(friend));
+
+        RunningSession activeSession = mock(RunningSession.class);
+        given(activeSession.getUserId()).willReturn(2L);
+        given(runningSessionRepository.findByUserIdInAndStatus(List.of(2L), RunningSessionStatus.ACTIVE))
+                .willReturn(List.of(activeSession));
+        given(runRecordRepository.findLatestByUserIds(List.of(2L))).willReturn(List.of());
+
+        // when
+        List<FriendListRes> result = friendService.getFriendsByUserId(1L);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getActivityStatus()).isEqualTo(FriendStatus.RUNNING.name());
+        assertThat(result.get(0).getLastActiveAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("ACTIVE 세션이 없고 러닝 기록이 있으면 OFFLINE 상태, lastActiveAt은 마지막 러닝 종료 시각")
+    void getFriendsByUserId_offlineWithRecord() {
+        // given
+        User friend = mock(User.class);
+        given(friend.getId()).willReturn(2L);
+        given(friendshipRepository.findFriendsByUserId(1L)).willReturn(List.of(friend));
+
+        given(runningSessionRepository.findByUserIdInAndStatus(List.of(2L), RunningSessionStatus.ACTIVE))
+                .willReturn(List.of());
+
+        RunRecord lastRecord = mock(RunRecord.class);
+        LocalDateTime lastActiveAt = LocalDateTime.of(2026, 5, 25, 10, 30);
+        given(lastRecord.getUserId()).willReturn(2L);
+        given(lastRecord.getLastActiveAt()).willReturn(lastActiveAt);
+        given(runRecordRepository.findLatestByUserIds(List.of(2L))).willReturn(List.of(lastRecord));
+
+        // when
+        List<FriendListRes> result = friendService.getFriendsByUserId(1L);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getActivityStatus()).isEqualTo(FriendStatus.OFFLINE.name());
+        assertThat(result.get(0).getLastActiveAt()).isEqualTo(lastActiveAt);
+    }
+
+    @Test
+    @DisplayName("ACTIVE 세션도 없고 러닝 기록도 없으면 OFFLINE 상태, lastActiveAt은 null")
+    void getFriendsByUserId_offlineNoRecord() {
+        // given
+        User friend = mock(User.class);
+        given(friend.getId()).willReturn(2L);
+        given(friendshipRepository.findFriendsByUserId(1L)).willReturn(List.of(friend));
+
+        given(runningSessionRepository.findByUserIdInAndStatus(List.of(2L), RunningSessionStatus.ACTIVE))
+                .willReturn(List.of());
+        given(runRecordRepository.findLatestByUserIds(List.of(2L))).willReturn(List.of());
+
+        // when
+        List<FriendListRes> result = friendService.getFriendsByUserId(1L);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getActivityStatus()).isEqualTo(FriendStatus.OFFLINE.name());
+        assertThat(result.get(0).getLastActiveAt()).isNull();
+    }
+}

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -7,7 +7,7 @@ import com._s3k.runsync.domain.run.repository.RunningSessionRepository;
 import com._s3k.runsync.entity.RunRecord;
 import com._s3k.runsync.entity.RunningSession;
 import com._s3k.runsync.entity.User;
-import com._s3k.runsync.entity.enums.FriendStatus;
+import com._s3k.runsync.entity.enums.ActivityStatus;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -20,6 +20,8 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
 
@@ -70,7 +72,7 @@ class FriendServiceTest {
 
         // then
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getActivityStatus()).isEqualTo(FriendStatus.RUNNING.name());
+        assertThat(result.get(0).getActivityStatus()).isEqualTo(ActivityStatus.RUNNING.name());
         assertThat(result.get(0).getLastActiveAt()).isNull();
     }
 
@@ -96,7 +98,7 @@ class FriendServiceTest {
 
         // then
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getActivityStatus()).isEqualTo(FriendStatus.OFFLINE.name());
+        assertThat(result.get(0).getActivityStatus()).isEqualTo(ActivityStatus.OFFLINE.name());
         assertThat(result.get(0).getLastActiveAt()).isEqualTo(lastActiveAt);
     }
 
@@ -117,7 +119,50 @@ class FriendServiceTest {
 
         // then
         assertThat(result).hasSize(1);
-        assertThat(result.get(0).getActivityStatus()).isEqualTo(FriendStatus.OFFLINE.name());
+        assertThat(result.get(0).getActivityStatus()).isEqualTo(ActivityStatus.OFFLINE.name());
         assertThat(result.get(0).getLastActiveAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("정렬 - RUNNING 먼저, OFFLINE은 lastActiveAt 최신순, 기록 없는 OFFLINE은 맨 뒤")
+    void getFriendsByUserId_sortOrder() {
+        // given
+        User running = mock(User.class);
+        given(running.getId()).willReturn(1L);
+        User offlineRecent = mock(User.class);
+        given(offlineRecent.getId()).willReturn(2L);
+        User offlineOld = mock(User.class);
+        given(offlineOld.getId()).willReturn(3L);
+        User offlineNoRecord = mock(User.class);
+        given(offlineNoRecord.getId()).willReturn(4L);
+
+        given(friendshipRepository.findFriendsByUserId(1L))
+                .willReturn(List.of(offlineNoRecord, offlineOld, offlineRecent, running)); // 의도적으로 섞인 순서
+
+        RunningSession activeSession = mock(RunningSession.class);
+        given(activeSession.getUserId()).willReturn(1L);
+        given(runningSessionRepository.findByUserIdInAndStatus(anyList(), eq(RunningSessionStatus.ACTIVE)))
+                .willReturn(List.of(activeSession));
+
+        RunRecord recentRecord = mock(RunRecord.class);
+        given(recentRecord.getUserId()).willReturn(2L);
+        given(recentRecord.getLastActiveAt()).willReturn(LocalDateTime.of(2026, 5, 25, 10, 30));
+
+        RunRecord oldRecord = mock(RunRecord.class);
+        given(oldRecord.getUserId()).willReturn(3L);
+        given(oldRecord.getLastActiveAt()).willReturn(LocalDateTime.of(2026, 5, 20, 8, 0));
+
+        given(runRecordRepository.findLatestByUserIds(anyList()))
+                .willReturn(List.of(recentRecord, oldRecord));
+
+        // when
+        List<FriendListRes> result = friendService.getFriendsByUserId(1L);
+
+        // then
+        assertThat(result).hasSize(4);
+        assertThat(result.get(0).getFriendUserId()).isEqualTo(1L); // RUNNING
+        assertThat(result.get(1).getFriendUserId()).isEqualTo(2L); // OFFLINE, 최신 기록
+        assertThat(result.get(2).getFriendUserId()).isEqualTo(3L); // OFFLINE, 오래된 기록
+        assertThat(result.get(3).getFriendUserId()).isEqualTo(4L); // OFFLINE, 기록 없음
     }
 }

--- a/src/test/java/com/_s3k/runsync/entity/RunRecordTest.java
+++ b/src/test/java/com/_s3k/runsync/entity/RunRecordTest.java
@@ -29,6 +29,22 @@ class RunRecordTest {
     }
 
     @Test
+    @DisplayName("getLastActiveAt - startTime + durationSeconds를 반환한다")
+    void getLastActiveAt() {
+        // given
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        LocalDateTime startTime = LocalDateTime.of(2026, 5, 25, 10, 0, 0);
+        RunRecord record = RunRecord.of(user, null, 1800, startTime,
+                BigDecimal.valueOf(5.0), null, null, null, null, null);
+
+        // when
+        LocalDateTime lastActiveAt = record.getLastActiveAt();
+
+        // then
+        assertThat(lastActiveAt).isEqualTo(startTime.plusSeconds(1800));
+    }
+
+    @Test
     @DisplayName("validateOwner - 다른 유저면 RECORD_NOT_OWNER 예외 발생")
     void validateOwner_notOwner() {
         // given


### PR DESCRIPTION
## #️⃣연관된 이슈

> #29 

## 📝작업 내용
- GET /api/friends 친구 목록 조회 API 구현
- activityStatus RUNNING / OFFLINE 두 가지 상태로 구분
- lastActiveAt OFFLINE 상태에서 마지막 러닝 종료 시각 반환, RUNNING 상태에서 null 반환
- 탈퇴한 친구 목록에서 제외 처리
- 친구 수에 비례한 N+1 쿼리 → bulk 조회로 개선 (최대 3쿼리 고정)
- FriendService, FriendController, FriendshipRepository, FriendListRes 구현
- FriendServiceTest, RunRecordTest 테스트 코드 작성

## 📷스크린샷 (선택)
<img width="1234" height="1234" alt="스크린샷 2026-05-25 오후 10 45 08" src="https://github.com/user-attachments/assets/405359c5-ab74-4cb4-86dc-4d54f6ecd68e" />