### PR TITLE
feat: 특정 사용자 프로필 조회 API 구현 (#32)

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/users/controller/UserController.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/controller/UserController.java
@@ -4,6 +4,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import jakarta.validation.Valid;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import com._s3k.runsync.domain.users.service.UserService;
 import com._s3k.runsync.domain.users.dto.request.UserUpdateReq;
 import com._s3k.runsync.domain.users.dto.response.UserInfoRes;
+import com._s3k.runsync.domain.users.dto.response.UserProfileRes;
 import com._s3k.runsync.domain.users.dto.response.UserUpdateRes;
 import com._s3k.runsync.global.common.dto.CommonResponse;
 
@@ -37,6 +39,19 @@ public class UserController {
     ) {
         UserInfoRes response = userService.getMyInfo(userId);
         return CommonResponse.success(response);
+    }
+
+    /**
+     * 특정 사용자 조회
+     * @param targetUserId 조회할 사용자 ID
+     */
+    @Operation(summary = "특정 사용자 조회", description = "특정 사용자 프로필 조회: 로그인 필요")
+    @GetMapping("/{userId}")
+    public CommonResponse<UserProfileRes> getUserById(
+            @Parameter(description = "조회할 사용자 ID", required = true)
+            @PathVariable("userId") Long targetUserId
+    ) {
+        return CommonResponse.success(userService.getUserById(targetUserId));
     }
 
     /**

--- a/src/main/java/com/_s3k/runsync/domain/users/dto/response/UserProfileRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/dto/response/UserProfileRes.java
@@ -23,7 +23,7 @@ public class UserProfileRes {
         this.profileImage = profileImage;
     }
 
-    public static UserProfileRes fromUser(User user) {
+    public static UserProfileRes of(User user) {
         return new UserProfileRes(user.getId(), user.getNickname(), user.getProfileImage());
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/users/dto/response/UserProfileRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/dto/response/UserProfileRes.java
@@ -1,0 +1,29 @@
+package com._s3k.runsync.domain.users.dto.response;
+
+import com._s3k.runsync.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "특정 사용자 조회 응답")
+public class UserProfileRes {
+
+    @Schema(description = "사용자 ID", example = "1")
+    private Long id;
+
+    @Schema(description = "닉네임", example = "run_hyunwoo")
+    private String nickname;
+
+    @Schema(description = "프로필 이미지 URL", example = "https://sample.com/new-profile.png")
+    private String profileImage;
+
+    private UserProfileRes(Long id, String nickname, String profileImage) {
+        this.id = id;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+    }
+
+    public static UserProfileRes fromUser(User user) {
+        return new UserProfileRes(user.getId(), user.getNickname(), user.getProfileImage());
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/users/service/UserService.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/service/UserService.java
@@ -31,6 +31,7 @@ public class UserService {
     @Transactional(readOnly = true)
     public UserProfileRes getUserById(Long targetUserId) {
         User user = userRepository.findById(targetUserId)
+                .filter(u -> !Boolean.TRUE.equals(u.getIsDeleted()))
                 .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
 
         return UserProfileRes.fromUser(user);

--- a/src/main/java/com/_s3k/runsync/domain/users/service/UserService.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/service/UserService.java
@@ -9,6 +9,7 @@ import com._s3k.runsync.domain.users.repository.UserRepository;
 import com._s3k.runsync.domain.users.exception.UserErrorCode;
 import com._s3k.runsync.domain.users.dto.request.UserUpdateReq;
 import com._s3k.runsync.domain.users.dto.response.UserInfoRes;
+import com._s3k.runsync.domain.users.dto.response.UserProfileRes;
 import com._s3k.runsync.domain.users.dto.response.UserUpdateRes;
 import com._s3k.runsync.global.exception.GlobalException;
 
@@ -25,6 +26,14 @@ public class UserService {
                 .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
 
         return UserInfoRes.of(user);
+    }
+
+    @Transactional(readOnly = true)
+    public UserProfileRes getUserById(Long targetUserId) {
+        User user = userRepository.findById(targetUserId)
+                .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
+
+        return UserProfileRes.fromUser(user);
     }
 
     @Transactional


### PR DESCRIPTION
## Related Issue
- Close #32

## Task
- GET /api/users/{userId} 엔드포인트 구현
- UserService.getUserById() 구현
- UserProfileRes 응답 DTO 구현 (id, nickname, profileImage)
- 탈퇴 사용자 조회 차단 처리 (Optional.filter)

## To Reviewer
- UserProfileRes는 타 사용자에게 공개되는 최소 정보만 포함 (내 정보 조회 UserInfoRes와 별도 DTO)
- 탈퇴 유저 필터링은 서비스 레이어에서 Optional.filter()로 처리 — DB 쿼리 추가 없이 서비스 책임으로 처리

## Check List
- [x] PR 제목 규칙 준수
- [x] 라벨과 리뷰어 설정
- [x] 민감파일(*.yml 등) .gitignore 설정

<img width="1152" height="894" alt="image" src="https://github.com/user-attachments/assets/176c8696-b6a5-4da4-abbd-164b4552fe89" />
