### PR TITLE
[Refactor] 친구 상태/위치 알림을 구독 기반 topic publish 방식으로 전환

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendshipRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendshipRepository.java
@@ -12,4 +12,6 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
 
     @Query("SELECT f.friend FROM Friendship f WHERE f.user.id = :userId AND f.friend.isDeleted = false")
     List<User> findFriendsByUserId(@Param("userId") Long userId);
+
+    boolean existsByUser_IdAndFriend_Id(Long userId, Long friendId);
 }

--- a/src/main/java/com/_s3k/runsync/domain/location/handler/LocationMessageHandler.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/handler/LocationMessageHandler.java
@@ -14,7 +14,6 @@ import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
-import java.util.Set;
 
 @Controller
 @RequiredArgsConstructor
@@ -40,18 +39,10 @@ public class LocationMessageHandler {
             );
         }
 
-        Set<String> friendIds = locationService.getFriendIds(userId);
-        if (friendIds.isEmpty()) return;
-
-        FriendLocationRes response = FriendLocationRes.of(userId, data.getLatitude(), data.getLongitude());
-
-        for (String friendId : friendIds) {
-            messagingTemplate.convertAndSendToUser(
-                    friendId,
-                    "/queue/location",
-                    WebSocketMessage.of("FRIEND_LOCATION_UPDATE", response)
-            );
-        }
+        messagingTemplate.convertAndSend(
+                "/topic/location/" + userId,
+                WebSocketMessage.of("FRIEND_LOCATION_UPDATE", FriendLocationRes.of(userId, data.getLatitude(), data.getLongitude()))
+        );
     }
 
     @MessageMapping("/ping")

--- a/src/main/java/com/_s3k/runsync/domain/location/handler/WebSocketEventListener.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/handler/WebSocketEventListener.java
@@ -5,7 +5,6 @@ import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.entity.enums.ActivityStatus;
 import com._s3k.runsync.global.websocket.dto.WebSocketMessage;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.event.EventListener;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
@@ -14,9 +13,7 @@ import org.springframework.web.socket.messaging.SessionConnectedEvent;
 import org.springframework.web.socket.messaging.SessionDisconnectEvent;
 
 import java.security.Principal;
-import java.util.Set;
 
-@Slf4j
 @Component
 @RequiredArgsConstructor
 public class WebSocketEventListener {
@@ -31,7 +28,10 @@ public class WebSocketEventListener {
         if (principal == null) return;
 
         Long userId = Long.parseLong(principal.getName());
-        notifyFriends(userId, ActivityStatus.RUNNING);
+        messagingTemplate.convertAndSend(
+                "/topic/status/" + userId,
+                WebSocketMessage.of("FRIEND_STATUS_CHANGE", ActivityStatusRes.of(userId, ActivityStatus.RUNNING))
+        );
     }
 
     @EventListener
@@ -42,28 +42,9 @@ public class WebSocketEventListener {
 
         Long userId = Long.parseLong(principal.getName());
         locationService.removeLocation(userId);
-        notifyFriends(userId, ActivityStatus.OFFLINE);
-    }
-
-    private void notifyFriends(Long userId, ActivityStatus status) {
-        Set<String> friendIds;
-        try {
-            friendIds = locationService.getFriendIds(userId);
-        } catch (Exception e) {
-            // 친구 목록 기능 미구현 상태에서 예외 발생 시 연결이 끊기는 것을 방지 (임시)
-            log.warn("친구 목록 조회 실패 userId={}: {}", userId, e.getMessage());
-            return;
-        }
-        if (friendIds == null || friendIds.isEmpty()) return;
-
-        ActivityStatusRes statusData = ActivityStatusRes.of(userId, status);
-
-        for (String friendId : friendIds) {
-            messagingTemplate.convertAndSendToUser(
-                    friendId,
-                    "/queue/status",
-                    WebSocketMessage.of("FRIEND_STATUS_CHANGE", statusData)
-            );
-        }
+        messagingTemplate.convertAndSend(
+                "/topic/status/" + userId,
+                WebSocketMessage.of("FRIEND_STATUS_CHANGE", ActivityStatusRes.of(userId, ActivityStatus.OFFLINE))
+        );
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/location/repository/LocationRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/repository/LocationRepository.java
@@ -1,12 +1,8 @@
 package com._s3k.runsync.domain.location.repository;
 
-import java.util.Set;
-
 public interface LocationRepository {
 
     void saveGeoLocation(Long userId, double longitude, double latitude);
-
-    Set<String> findFriendIds(Long userId);
 
     void deleteGeoLocation(Long userId);
 }

--- a/src/main/java/com/_s3k/runsync/domain/location/repository/LocationRepositoryImpl.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/repository/LocationRepositoryImpl.java
@@ -7,8 +7,6 @@ import org.springframework.data.geo.Point;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
-import java.util.Set;
-
 @Repository
 @RequiredArgsConstructor
 public class LocationRepositoryImpl implements LocationRepository {
@@ -22,11 +20,6 @@ public class LocationRepositoryImpl implements LocationRepository {
         } catch (Exception e) {
             throw new GlobalException(LocationErrorCode.LOCATION_SAVE_FAILED);
         }
-    }
-
-    @Override
-    public Set<String> findFriendIds(Long userId) {
-        return redisTemplate.opsForSet().members("user:" + userId + ":friends");
     }
 
     @Override

--- a/src/main/java/com/_s3k/runsync/domain/location/service/LocationService.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/service/LocationService.java
@@ -1,5 +1,6 @@
 package com._s3k.runsync.domain.location.service;
 
+import com._s3k.runsync.domain.friend.repository.FriendshipRepository;
 import com._s3k.runsync.domain.location.dto.request.LocationUpdateReq;
 import com._s3k.runsync.domain.location.exception.LocationErrorCode;
 import com._s3k.runsync.domain.location.repository.LocationRepository;
@@ -7,13 +8,12 @@ import com._s3k.runsync.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
-import java.util.Set;
-
 @Service
 @RequiredArgsConstructor
 public class LocationService {
 
     private final LocationRepository locationRepository;
+    private final FriendshipRepository friendshipRepository;
 
     public void saveGeoLocation(Long userId, LocationUpdateReq data) {
         if (data == null || data.getLatitude() == null || data.getLongitude() == null) {
@@ -23,8 +23,8 @@ public class LocationService {
         locationRepository.saveGeoLocation(userId, data.getLongitude(), data.getLatitude());
     }
 
-    public Set<String> getFriendIds(Long userId) {
-        return locationRepository.findFriendIds(userId);
+    public boolean canSubscribeFriendTopic(Long subscriberId, Long targetUserId) {
+        return friendshipRepository.existsByUser_IdAndFriend_Id(subscriberId, targetUserId);
     }
 
     public void removeLocation(Long userId) {

--- a/src/main/java/com/_s3k/runsync/global/config/WebSocketConfig.java
+++ b/src/main/java/com/_s3k/runsync/global/config/WebSocketConfig.java
@@ -18,7 +18,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Override
     public void configureMessageBroker(MessageBrokerRegistry registry) {
-        registry.enableSimpleBroker("/queue");
+        registry.enableSimpleBroker("/queue", "/topic");
         registry.setApplicationDestinationPrefixes("/app");
         registry.setUserDestinationPrefix("/user");
     }

--- a/src/main/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptor.java
@@ -1,5 +1,6 @@
 package com._s3k.runsync.global.websocket.interceptor;
 
+import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.global.security.jwt.JwtValidator;
 import com._s3k.runsync.global.security.jwt.dto.JwtUserInfo;
 import lombok.RequiredArgsConstructor;
@@ -15,13 +16,17 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class WebSocketAuthInterceptor implements ChannelInterceptor {
 
+    private static final String FRIEND_TOPIC_PATTERN = "^/topic/(status|location)/\\d+$";
+
     private final JwtValidator jwtValidator;
+    private final LocationService locationService;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
         StompHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor.class);
+        if (accessor == null) return message;
 
-        if (accessor != null && StompCommand.CONNECT.equals(accessor.getCommand())) {
+        if (StompCommand.CONNECT.equals(accessor.getCommand())) {
             String authHeader = accessor.getFirstNativeHeader("Authorization");
 
             if (authHeader == null || !authHeader.startsWith("Bearer ")) {
@@ -36,6 +41,35 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
 
             JwtUserInfo userInfo = jwtValidator.getUserIdAndRole(token);
             accessor.setUser(() -> String.valueOf(userInfo.getUserId()));
+        }
+
+        if (StompCommand.SUBSCRIBE.equals(accessor.getCommand())) {
+            String destination = accessor.getDestination();
+            if (destination == null) return message;
+
+            boolean isProtectedTopic = destination.equals("/topic/status") || destination.startsWith("/topic/status/")
+                    || destination.equals("/topic/location") || destination.startsWith("/topic/location/");
+            boolean isValidProtectedTopic = destination.matches(FRIEND_TOPIC_PATTERN);
+
+            if (isProtectedTopic && !isValidProtectedTopic) {
+                throw new IllegalArgumentException("잘못된 구독 경로입니다.");
+            }
+
+            if (isValidProtectedTopic) {
+                if (accessor.getUser() == null) {
+                    throw new IllegalArgumentException("인증되지 않은 사용자입니다.");
+                }
+
+                String targetUserId = destination.substring(destination.lastIndexOf('/') + 1);
+                String subscriberUserId = accessor.getUser().getName();
+                if (subscriberUserId.equals(targetUserId)) {
+                    throw new IllegalArgumentException("자기 자신을 구독할 수 없습니다.");
+                }
+
+                if (!locationService.canSubscribeFriendTopic(Long.parseLong(subscriberUserId), Long.parseLong(targetUserId))) {
+                    throw new IllegalArgumentException("친구가 아닌 사용자의 상태/위치를 구독할 수 없습니다.");
+                }
+            }
         }
 
         return message;

--- a/src/test/java/com/_s3k/runsync/domain/location/repository/LocationRepositoryImplTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/location/repository/LocationRepositoryImplTest.java
@@ -10,10 +10,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.geo.Point;
 import org.springframework.data.redis.core.GeoOperations;
-import org.springframework.data.redis.core.SetOperations;
 import org.springframework.data.redis.core.StringRedisTemplate;
-
-import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -60,21 +57,6 @@ class LocationRepositoryImplTest {
                 .isInstanceOf(GlobalException.class)
                 .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
                         .isEqualTo(LocationErrorCode.LOCATION_SAVE_FAILED));
-    }
-
-    @Test
-    @DisplayName("친구 ID 목록 조회 성공")
-    void findFriendIds_success() {
-        // given
-        SetOperations<String, String> setOps = mock(SetOperations.class);
-        given(redisTemplate.opsForSet()).willReturn(setOps);
-        given(setOps.members("user:1:friends")).willReturn(Set.of("2", "3"));
-
-        // when
-        Set<String> result = locationRepository.findFriendIds(1L);
-
-        // then
-        assertThat(result).containsExactlyInAnyOrder("2", "3");
     }
 
     @Test

--- a/src/test/java/com/_s3k/runsync/domain/location/service/LocationServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/location/service/LocationServiceTest.java
@@ -1,5 +1,6 @@
 package com._s3k.runsync.domain.location.service;
 
+import com._s3k.runsync.domain.friend.repository.FriendshipRepository;
 import com._s3k.runsync.domain.location.dto.request.LocationUpdateReq;
 import com._s3k.runsync.domain.location.exception.LocationErrorCode;
 import com._s3k.runsync.domain.location.repository.LocationRepository;
@@ -16,6 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyDouble;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -27,6 +29,9 @@ class LocationServiceTest {
 
     @Mock
     private LocationRepository locationRepository;
+
+    @Mock
+    private FriendshipRepository friendshipRepository;
 
     private LocationUpdateReq createReq(Long sessionId, Double latitude, Double longitude, Double speed) {
         LocationUpdateReq req = new LocationUpdateReq();
@@ -75,6 +80,32 @@ class LocationServiceTest {
                         .isEqualTo(LocationErrorCode.INVALID_LOCATION_DATA));
 
         verify(locationRepository, never()).saveGeoLocation(anyLong(), anyDouble(), anyDouble());
+    }
+
+    @Test
+    @DisplayName("친구이면 구독 허용")
+    void canSubscribeFriendTopic_friendExists_returnsTrue() {
+        // given
+        given(friendshipRepository.existsByUser_IdAndFriend_Id(1L, 2L)).willReturn(true);
+
+        // when
+        boolean result = locationService.canSubscribeFriendTopic(1L, 2L);
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("친구가 아니면 구독 거부")
+    void canSubscribeFriendTopic_friendNotExists_returnsFalse() {
+        // given
+        given(friendshipRepository.existsByUser_IdAndFriend_Id(1L, 2L)).willReturn(false);
+
+        // when
+        boolean result = locationService.canSubscribeFriendTopic(1L, 2L);
+
+        // then
+        assertThat(result).isFalse();
     }
 
     @Test

--- a/src/test/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptorTest.java
+++ b/src/test/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptorTest.java
@@ -1,0 +1,136 @@
+package com._s3k.runsync.global.websocket.interceptor;
+
+import com._s3k.runsync.domain.location.service.LocationService;
+import com._s3k.runsync.global.security.jwt.JwtValidator;
+import com._s3k.runsync.global.security.jwt.dto.JwtUserInfo;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.simp.stomp.StompCommand;
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
+import org.springframework.messaging.support.MessageBuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+
+@ExtendWith(MockitoExtension.class)
+class WebSocketAuthInterceptorTest {
+
+    @InjectMocks
+    private WebSocketAuthInterceptor interceptor;
+
+    @Mock
+    private JwtValidator jwtValidator;
+
+    @Mock
+    private LocationService locationService;
+
+    @Mock
+    private MessageChannel channel;
+
+    private Message<?> buildSubscribeMessage(String destination, String principalName) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setDestination(destination);
+        if (principalName != null) {
+            accessor.setUser(() -> principalName);
+        }
+        accessor.setSessionId("test-session");
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    @Test
+    @DisplayName("친구 topic 정상 구독 허용")
+    void subscribe_validFriendTopic_allowed() {
+        // given
+        given(locationService.canSubscribeFriendTopic(1L, 2L)).willReturn(true);
+        Message<?> message = buildSubscribeMessage("/topic/status/2", "1");
+
+        // when
+        Message<?> result = interceptor.preSend(message, channel);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("친구가 아닌 사용자 구독 거부")
+    void subscribe_notFriend_throwsException() {
+        // given
+        given(locationService.canSubscribeFriendTopic(1L, 2L)).willReturn(false);
+        Message<?> message = buildSubscribeMessage("/topic/location/2", "1");
+
+        // when & then
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("친구가 아닌 사용자의 상태/위치를 구독할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("자기 자신 구독 거부")
+    void subscribe_selfSubscription_throwsException() {
+        // given
+        Message<?> message = buildSubscribeMessage("/topic/status/1", "1");
+
+        // when & then
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("자기 자신을 구독할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("malformed topic 거부")
+    void subscribe_malformedTopic_throwsException() {
+        // given
+        Message<?> message = buildSubscribeMessage("/topic/status/abc", "1");
+
+        // when & then
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("잘못된 구독 경로입니다.");
+    }
+
+    @Test
+    @DisplayName("인증 없는 친구 topic 구독 거부")
+    void subscribe_noAuthentication_throwsException() {
+        // given
+        Message<?> message = buildSubscribeMessage("/topic/status/2", null);
+
+        // when & then
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("인증되지 않은 사용자입니다.");
+    }
+
+    @Test
+    @DisplayName("/user/queue/ping 구독 시 영향 없음")
+    void subscribe_pingQueue_notAffected() {
+        // given
+        Message<?> message = buildSubscribeMessage("/user/queue/ping", "1");
+
+        // when
+        Message<?> result = interceptor.preSend(message, channel);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("/user/queue/errors 구독 시 영향 없음")
+    void subscribe_errorsQueue_notAffected() {
+        // given
+        Message<?> message = buildSubscribeMessage("/user/queue/errors", "1");
+
+        // when
+        Message<?> result = interceptor.preSend(message, channel);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #31 

## 📝작업 내용

기존 WebSocket 알림 방식을 push → subscribe/publish 방식으로 전환했습니다.

  **변경 전**
  - 상태/위치 이벤트 발생마다 서버가 친구 목록을 Redis에서 조회
  - 각 친구에게 개별 메시지 push (`/user/queue/status`, `/user/queue/location`)

  **변경 후**
  - 클라이언트가 `/topic/status/{userId}`, `/topic/location/{userId}` 구독
  - 서버는 해당 topic에만 publish → 브로커가 구독자에게 전달
  - 친구 여부 검증을 구독 시점 1회로 변경 (DB Friendship 테이블 기준)

## 📷스크린샷 (선택)
<img width="2534" height="1229" alt="스크린샷 2026-06-01 오후 10 44 14" src="https://github.com/user-attachments/assets/62263aab-d955-4f63-beb0-ada53e145981" />
<img width="2547" height="1236" alt="스크린샷 2026-06-01 오후 10 44 39" src="https://github.com/user-attachments/assets/cd6538fc-817c-4d3a-aff7-da3e825fafbf" />