### PR TITLE
[Feat] 협동 러닝 세션 생성 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/artrun/controller/ArtRunController.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/controller/ArtRunController.java
@@ -1,0 +1,31 @@
+package com._s3k.runsync.domain.artrun.controller;
+
+import com._s3k.runsync.domain.artrun.dto.request.ArtRunCreateReq;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunCreateRes;
+import com._s3k.runsync.domain.artrun.service.ArtRunService;
+import com._s3k.runsync.global.common.dto.CommonResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/art-runs")
+@RequiredArgsConstructor
+public class ArtRunController {
+
+    private final ArtRunService artRunService;
+
+    @PostMapping
+    @Operation(summary = "협동 러닝 세션 생성", description = "도안 좌표와 모임 정보로 협동 러닝 세션을 생성합니다. 로그인 필요")
+    public CommonResponse<ArtRunCreateRes> createArtRun(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody ArtRunCreateReq request
+    ) {
+        return CommonResponse.success(artRunService.createArtRun(userId, request));
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/request/ArtRunCreateReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/request/ArtRunCreateReq.java
@@ -1,0 +1,45 @@
+package com._s3k.runsync.domain.artrun.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.FutureOrPresent;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "협동 러닝 세션 생성 요청")
+public class ArtRunCreateReq {
+
+    @NotBlank
+    @Schema(description = "모집 제목", example = "강아지런 같이 그려요")
+    private String title;
+
+    @NotNull
+    @Min(2)
+    @Schema(description = "정원 (호스트 포함, 최소 2명)", example = "5")
+    private Integer capacity;
+
+    @NotNull
+    @FutureOrPresent
+    @Schema(description = "모이는 시간", example = "2026-06-10T07:00:00")
+    private LocalDateTime meetingTime;
+
+    @NotNull
+    @Valid
+    @Schema(description = "모이는 장소")
+    private MeetingPlaceReq meetingPlace;
+
+    @NotNull
+    @Size(min = 2)
+    @Valid
+    @Schema(description = "도안 좌표 (그리는 순서, 2개 이상)")
+    private List<CoordinateReq> coordinates;
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/request/CoordinateReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/request/CoordinateReq.java
@@ -1,0 +1,26 @@
+package com._s3k.runsync.domain.artrun.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "좌표")
+public class CoordinateReq {
+
+    @NotNull
+    @DecimalMin("-90")
+    @DecimalMax("90")
+    @Schema(description = "위도", example = "37.5210")
+    private Double latitude;
+
+    @NotNull
+    @DecimalMin("-180")
+    @DecimalMax("180")
+    @Schema(description = "경도", example = "127.1230")
+    private Double longitude;
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/request/MeetingPlaceReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/request/MeetingPlaceReq.java
@@ -1,0 +1,31 @@
+package com._s3k.runsync.domain.artrun.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "모이는 장소")
+public class MeetingPlaceReq {
+
+    @NotBlank
+    @Schema(description = "장소 이름", example = "올림픽공원 평화의문 앞")
+    private String name;
+
+    @NotNull
+    @DecimalMin("-90")
+    @DecimalMax("90")
+    @Schema(description = "장소 위도", example = "37.5202")
+    private Double latitude;
+
+    @NotNull
+    @DecimalMin("-180")
+    @DecimalMax("180")
+    @Schema(description = "장소 경도", example = "127.1210")
+    private Double longitude;
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunCreateRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunCreateRes.java
@@ -1,0 +1,21 @@
+package com._s3k.runsync.domain.artrun.dto.response;
+
+import com._s3k.runsync.entity.ArtRunSession;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "협동 러닝 세션 생성 응답")
+public class ArtRunCreateRes {
+
+    @Schema(description = "생성된 세션 ID", example = "100")
+    private final Long sessionId;
+
+    private ArtRunCreateRes(Long sessionId) {
+        this.sessionId = sessionId;
+    }
+
+    public static ArtRunCreateRes of(ArtRunSession session) {
+        return new ArtRunCreateRes(session.getId());
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunParticipantRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunParticipantRepository.java
@@ -1,0 +1,7 @@
+package com._s3k.runsync.domain.artrun.repository;
+
+import com._s3k.runsync.entity.ArtRunParticipant;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArtRunParticipantRepository extends JpaRepository<ArtRunParticipant, Long> {
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunSessionRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunSessionRepository.java
@@ -1,0 +1,7 @@
+package com._s3k.runsync.domain.artrun.repository;
+
+import com._s3k.runsync.entity.ArtRunSession;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ArtRunSessionRepository extends JpaRepository<ArtRunSession, Long> {
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
@@ -1,0 +1,67 @@
+package com._s3k.runsync.domain.artrun.service;
+
+import com._s3k.runsync.domain.artrun.dto.request.ArtRunCreateReq;
+import com._s3k.runsync.domain.artrun.dto.request.CoordinateReq;
+import com._s3k.runsync.domain.artrun.dto.request.MeetingPlaceReq;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunCreateRes;
+import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
+import com._s3k.runsync.domain.artrun.repository.ArtRunSessionRepository;
+import com._s3k.runsync.domain.users.exception.UserErrorCode;
+import com._s3k.runsync.domain.users.repository.UserRepository;
+import com._s3k.runsync.entity.ArtRunParticipant;
+import com._s3k.runsync.entity.ArtRunSession;
+import com._s3k.runsync.entity.User;
+import com._s3k.runsync.global.exception.GlobalException;
+import lombok.RequiredArgsConstructor;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class ArtRunService {
+
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
+
+    private final UserRepository userRepository;
+    private final ArtRunSessionRepository artRunSessionRepository;
+    private final ArtRunParticipantRepository artRunParticipantRepository;
+
+    @Transactional
+    public ArtRunCreateRes createArtRun(Long userId, ArtRunCreateReq request) {
+        User host = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
+
+        MeetingPlaceReq place = request.getMeetingPlace();
+        ArtRunSession session = ArtRunSession.of(
+                host,
+                request.getTitle(),
+                request.getCapacity(),
+                request.getMeetingTime(),
+                place.getName(),
+                toPoint(place.getLatitude(), place.getLongitude()),
+                toLineString(request.getCoordinates())
+        );
+        artRunSessionRepository.save(session);
+        artRunParticipantRepository.save(ArtRunParticipant.of(session, host));
+
+        return ArtRunCreateRes.of(session);
+    }
+
+    private Point toPoint(double latitude, double longitude) {
+        return GEOMETRY_FACTORY.createPoint(new Coordinate(longitude, latitude));
+    }
+
+    private LineString toLineString(List<CoordinateReq> coordinates) {
+        Coordinate[] coords = coordinates.stream()
+                .map(c -> new Coordinate(c.getLongitude(), c.getLatitude()))
+                .toArray(Coordinate[]::new);
+        return GEOMETRY_FACTORY.createLineString(coords);
+    }
+}

--- a/src/main/java/com/_s3k/runsync/entity/ArtRunParticipant.java
+++ b/src/main/java/com/_s3k/runsync/entity/ArtRunParticipant.java
@@ -1,0 +1,37 @@
+package com._s3k.runsync.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "art_run_participant", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"art_run_session_id", "user_id"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArtRunParticipant extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "art_run_session_id", nullable = false)
+    private ArtRunSession artRunSession;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ArtRunParticipant(ArtRunSession artRunSession, User user) {
+        this.artRunSession = artRunSession;
+        this.user = user;
+    }
+
+    public static ArtRunParticipant of(ArtRunSession artRunSession, User user) {
+        return ArtRunParticipant.builder()
+                .artRunSession(artRunSession)
+                .user(user)
+                .build();
+    }
+}

--- a/src/main/java/com/_s3k/runsync/entity/ArtRunSession.java
+++ b/src/main/java/com/_s3k/runsync/entity/ArtRunSession.java
@@ -1,0 +1,74 @@
+package com._s3k.runsync.entity;
+
+import com._s3k.runsync.entity.enums.ArtRunStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "art_run_session")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ArtRunSession extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "host_id", nullable = false)
+    private User host;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ArtRunStatus status;
+
+    @Column(nullable = false, length = 100)
+    private String title;
+
+    @Column(nullable = false)
+    private Integer capacity;
+
+    @Column(name = "meeting_time", nullable = false)
+    private LocalDateTime meetingTime;
+
+    @Column(name = "meeting_place_name", nullable = false)
+    private String meetingPlaceName;
+
+    @Column(name = "meeting_point", columnDefinition = "geometry(Point, 4326)", nullable = false)
+    private Point meetingPoint;
+
+    @Column(name = "route_path", columnDefinition = "geometry(LineString, 4326)", nullable = false)
+    private LineString routePath;
+
+    @Column(name = "host_id", insertable = false, updatable = false)
+    private Long hostId;
+
+    @Builder(access = AccessLevel.PRIVATE)
+    private ArtRunSession(User host, String title, Integer capacity, LocalDateTime meetingTime,
+                          String meetingPlaceName, Point meetingPoint, LineString routePath) {
+        this.host = host;
+        this.title = title;
+        this.capacity = capacity;
+        this.meetingTime = meetingTime;
+        this.meetingPlaceName = meetingPlaceName;
+        this.meetingPoint = meetingPoint;
+        this.routePath = routePath;
+        this.status = ArtRunStatus.RECRUITING;
+    }
+
+    public static ArtRunSession of(User host, String title, Integer capacity, LocalDateTime meetingTime,
+                                   String meetingPlaceName, Point meetingPoint, LineString routePath) {
+        return ArtRunSession.builder()
+                .host(host)
+                .title(title)
+                .capacity(capacity)
+                .meetingTime(meetingTime)
+                .meetingPlaceName(meetingPlaceName)
+                .meetingPoint(meetingPoint)
+                .routePath(routePath)
+                .build();
+    }
+}

--- a/src/main/java/com/_s3k/runsync/entity/enums/ArtRunStatus.java
+++ b/src/main/java/com/_s3k/runsync/entity/enums/ArtRunStatus.java
@@ -1,0 +1,10 @@
+package com._s3k.runsync.entity.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum ArtRunStatus {
+    RECRUITING,
+    IN_PROGRESS,
+    COMPLETED
+}

--- a/src/test/java/com/_s3k/runsync/domain/artrun/dto/request/ArtRunCreateReqTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/artrun/dto/request/ArtRunCreateReqTest.java
@@ -1,0 +1,119 @@
+package com._s3k.runsync.domain.artrun.dto.request;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ArtRunCreateReqTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        try (ValidatorFactory factory = Validation.buildDefaultValidatorFactory()) {
+            validator = factory.getValidator();
+        }
+    }
+
+    @Test
+    @DisplayName("유효한 요청은 위반이 없다")
+    void valid_noViolations() {
+        ArtRunCreateReq request = validRequest();
+
+        Set<ConstraintViolation<ArtRunCreateReq>> violations = validator.validate(request);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("정원이 2명 미만이면 검증에 실패한다")
+    void capacity_lessThanTwo() {
+        ArtRunCreateReq request = validRequest();
+        ReflectionTestUtils.setField(request, "capacity", 1);
+
+        Set<ConstraintViolation<ArtRunCreateReq>> violations = validator.validate(request);
+
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("capacity"));
+    }
+
+    @Test
+    @DisplayName("좌표가 2개 미만이면 검증에 실패한다")
+    void coordinates_lessThanTwo() {
+        ArtRunCreateReq request = validRequest();
+        ReflectionTestUtils.setField(request, "coordinates", List.of(coord(37.5210, 127.1230)));
+
+        Set<ConstraintViolation<ArtRunCreateReq>> violations = validator.validate(request);
+
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("coordinates"));
+    }
+
+    @Test
+    @DisplayName("모이는 시간이 과거이면 검증에 실패한다")
+    void meetingTime_past() {
+        ArtRunCreateReq request = validRequest();
+        ReflectionTestUtils.setField(request, "meetingTime", LocalDateTime.now().minusDays(1));
+
+        Set<ConstraintViolation<ArtRunCreateReq>> violations = validator.validate(request);
+
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("meetingTime"));
+    }
+
+    @Test
+    @DisplayName("좌표 위도가 범위를 벗어나면 검증에 실패한다")
+    void coordinate_latitudeOutOfRange() {
+        ArtRunCreateReq request = validRequest();
+        ReflectionTestUtils.setField(request, "coordinates", List.of(coord(999.0, 127.1230), coord(37.5215, 127.1242)));
+
+        Set<ConstraintViolation<ArtRunCreateReq>> violations = validator.validate(request);
+
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().contains("latitude"));
+    }
+
+    @Test
+    @DisplayName("모임 장소 경도가 범위를 벗어나면 검증에 실패한다")
+    void meetingPlace_longitudeOutOfRange() {
+        ArtRunCreateReq request = validRequest();
+        MeetingPlaceReq place = new MeetingPlaceReq();
+        ReflectionTestUtils.setField(place, "name", "올림픽공원 평화의문 앞");
+        ReflectionTestUtils.setField(place, "latitude", 37.5202);
+        ReflectionTestUtils.setField(place, "longitude", 999.0);
+        ReflectionTestUtils.setField(request, "meetingPlace", place);
+
+        Set<ConstraintViolation<ArtRunCreateReq>> violations = validator.validate(request);
+
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().contains("longitude"));
+    }
+
+    private ArtRunCreateReq validRequest() {
+        MeetingPlaceReq place = new MeetingPlaceReq();
+        ReflectionTestUtils.setField(place, "name", "올림픽공원 평화의문 앞");
+        ReflectionTestUtils.setField(place, "latitude", 37.5202);
+        ReflectionTestUtils.setField(place, "longitude", 127.1210);
+
+        ArtRunCreateReq request = new ArtRunCreateReq();
+        ReflectionTestUtils.setField(request, "title", "강아지런 같이 그려요");
+        ReflectionTestUtils.setField(request, "capacity", 5);
+        ReflectionTestUtils.setField(request, "meetingTime", LocalDateTime.now().plusDays(1));
+        ReflectionTestUtils.setField(request, "meetingPlace", place);
+        ReflectionTestUtils.setField(request, "coordinates", List.of(coord(37.5210, 127.1230), coord(37.5215, 127.1242)));
+        return request;
+    }
+
+    private CoordinateReq coord(double latitude, double longitude) {
+        CoordinateReq coordinate = new CoordinateReq();
+        ReflectionTestUtils.setField(coordinate, "latitude", latitude);
+        ReflectionTestUtils.setField(coordinate, "longitude", longitude);
+        return coordinate;
+    }
+}

--- a/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
@@ -1,0 +1,121 @@
+package com._s3k.runsync.domain.artrun.service;
+
+import com._s3k.runsync.domain.artrun.dto.request.ArtRunCreateReq;
+import com._s3k.runsync.domain.artrun.dto.request.CoordinateReq;
+import com._s3k.runsync.domain.artrun.dto.request.MeetingPlaceReq;
+import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
+import com._s3k.runsync.domain.artrun.repository.ArtRunSessionRepository;
+import com._s3k.runsync.domain.users.exception.UserErrorCode;
+import com._s3k.runsync.domain.users.repository.UserRepository;
+import com._s3k.runsync.entity.ArtRunParticipant;
+import com._s3k.runsync.entity.ArtRunSession;
+import com._s3k.runsync.entity.User;
+import com._s3k.runsync.entity.enums.ArtRunStatus;
+import com._s3k.runsync.entity.enums.Provider;
+import com._s3k.runsync.global.exception.GlobalException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ArtRunServiceTest {
+
+    @InjectMocks
+    private ArtRunService artRunService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private ArtRunSessionRepository artRunSessionRepository;
+
+    @Mock
+    private ArtRunParticipantRepository artRunParticipantRepository;
+
+    @Test
+    @DisplayName("협동 러닝 세션 생성 성공 - RECRUITING 상태로 저장되고 좌표가 경도/위도 순으로 저장된다")
+    void createArtRun_success() {
+        // given
+        Long userId = 1L;
+        ArtRunCreateReq request = createRequest();
+
+        User host = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        given(userRepository.findById(userId)).willReturn(Optional.of(host));
+        given(artRunSessionRepository.save(any(ArtRunSession.class))).willAnswer(i -> i.getArgument(0));
+
+        // when
+        artRunService.createArtRun(userId, request);
+
+        // then
+        ArgumentCaptor<ArtRunSession> captor = ArgumentCaptor.forClass(ArtRunSession.class);
+        verify(artRunSessionRepository).save(captor.capture());
+        ArtRunSession saved = captor.getValue();
+
+        assertThat(saved.getStatus()).isEqualTo(ArtRunStatus.RECRUITING);
+        assertThat(saved.getMeetingPoint().getX()).isEqualTo(127.1210); // X = longitude
+        assertThat(saved.getMeetingPoint().getY()).isEqualTo(37.5202);  // Y = latitude
+        assertThat(saved.getRoutePath().getCoordinateN(0).x).isEqualTo(127.1230); // x = longitude
+        assertThat(saved.getRoutePath().getCoordinateN(0).y).isEqualTo(37.5210);  // y = latitude
+        assertThat(saved.getRoutePath().getNumPoints()).isEqualTo(2);
+
+        ArgumentCaptor<ArtRunParticipant> participantCaptor = ArgumentCaptor.forClass(ArtRunParticipant.class);
+        verify(artRunParticipantRepository).save(participantCaptor.capture());
+        assertThat(participantCaptor.getValue().getUser()).isEqualTo(host);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 유저로 세션 생성 시 예외 발생")
+    void createArtRun_userNotFound() {
+        // given
+        Long userId = 1L;
+        ArtRunCreateReq request = createRequest();
+        given(userRepository.findById(userId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.createArtRun(userId, request))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+
+        verify(artRunSessionRepository, never()).save(any());
+        verify(artRunParticipantRepository, never()).save(any());
+    }
+
+    private ArtRunCreateReq createRequest() {
+        MeetingPlaceReq place = new MeetingPlaceReq();
+        ReflectionTestUtils.setField(place, "name", "올림픽공원 평화의문 앞");
+        ReflectionTestUtils.setField(place, "latitude", 37.5202);
+        ReflectionTestUtils.setField(place, "longitude", 127.1210);
+
+        ArtRunCreateReq request = new ArtRunCreateReq();
+        ReflectionTestUtils.setField(request, "title", "강아지런 같이 그려요");
+        ReflectionTestUtils.setField(request, "capacity", 5);
+        ReflectionTestUtils.setField(request, "meetingTime", LocalDateTime.now().plusDays(1));
+        ReflectionTestUtils.setField(request, "meetingPlace", place);
+        ReflectionTestUtils.setField(request, "coordinates", List.of(coord(37.5210, 127.1230), coord(37.5215, 127.1242)));
+        return request;
+    }
+
+    private CoordinateReq coord(double latitude, double longitude) {
+        CoordinateReq coordinate = new CoordinateReq();
+        ReflectionTestUtils.setField(coordinate, "latitude", latitude);
+        ReflectionTestUtils.setField(coordinate, "longitude", longitude);
+        return coordinate;
+    }
+}

--- a/src/test/java/com/_s3k/runsync/entity/ArtRunSessionTest.java
+++ b/src/test/java/com/_s3k/runsync/entity/ArtRunSessionTest.java
@@ -1,0 +1,46 @@
+package com._s3k.runsync.entity;
+
+import com._s3k.runsync.entity.enums.ArtRunStatus;
+import com._s3k.runsync.entity.enums.Provider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ArtRunSessionTest {
+
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
+
+    @Test
+    @DisplayName("세션 생성 시 초기 상태가 RECRUITING이고 전달받은 값으로 조립된다")
+    void of_initialStatusIsRecruiting() {
+        // given
+        User host = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        LocalDateTime meetingTime = LocalDateTime.now().plusDays(1);
+        Point meetingPoint = GEOMETRY_FACTORY.createPoint(new Coordinate(127.1210, 37.5202));
+        LineString routePath = GEOMETRY_FACTORY.createLineString(new Coordinate[]{
+                new Coordinate(127.1230, 37.5210),
+                new Coordinate(127.1242, 37.5215)
+        });
+
+        // when
+        ArtRunSession session = ArtRunSession.of(host, "강아지런", 5, meetingTime,
+                "올림픽공원 평화의문 앞", meetingPoint, routePath);
+
+        // then
+        assertThat(session.getStatus()).isEqualTo(ArtRunStatus.RECRUITING);
+        assertThat(session.getTitle()).isEqualTo("강아지런");
+        assertThat(session.getCapacity()).isEqualTo(5);
+        assertThat(session.getMeetingTime()).isEqualTo(meetingTime);
+        assertThat(session.getMeetingPlaceName()).isEqualTo("올림픽공원 평화의문 앞");
+        assertThat(session.getMeetingPoint()).isEqualTo(meetingPoint);
+        assertThat(session.getRoutePath()).isEqualTo(routePath);
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #36

## 📝작업 내용
- POST /api/art-runs 협동 러닝 세션 생성 API 구현
- 도안 좌표·모임 정보(시간/장소/정원)로 세션 생성
- 도안 좌표를 PostGIS LineString, 모임 장소를 Point로 저장 (SRID 4326)
- 세션 생성자를 host이자 첫 참가자로 자동 등록 (정원은 host 포함, 최소 2명)
- 입력 검증 추가: 좌표 2개 이상 / 위·경도 범위 / 미래 모임 시간 / 정원 2명 이상
- ArtRunSession, ArtRunParticipant 엔티티 및 ArtRunStatus enum 구현
- ArtRunService, ArtRunController, ArtRunSessionRepository, ArtRunParticipantRepository 구현
- ArtRunCreateReq, MeetingPlaceReq, CoordinateReq, ArtRunCreateRes DTO 구현
- ArtRunServiceTest, ArtRunSessionTest, ArtRunCreateReqTest 테스트 코드 작성

## 📷스크린샷 (선택)
<img width="1440" height="548" alt="스크린샷 2026-06-02 오후 8 38 00" src="https://github.com/user-attachments/assets/034a1fbc-2539-431f-b6c2-71b2149535ec" />
<img width="1441" height="761" alt="스크린샷 2026-06-02 오후 8 37 54" src="https://github.com/user-attachments/assets/68f484f0-5c17-440b-a954-1473038d51db" />
