### PR TITLE
[Feat] 협동 러닝 세션 목록/상세 조회 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/artrun/controller/ArtRunController.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/controller/ArtRunController.java
@@ -2,20 +2,30 @@ package com._s3k.runsync.domain.artrun.controller;
 
 import com._s3k.runsync.domain.artrun.dto.request.ArtRunCreateReq;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunCreateRes;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunDetailRes;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunScrollRes;
 import com._s3k.runsync.domain.artrun.service.ArtRunService;
+import com._s3k.runsync.entity.enums.ArtRunStatus;
 import com._s3k.runsync.global.common.dto.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/art-runs")
 @RequiredArgsConstructor
+@Validated
 public class ArtRunController {
 
     private final ArtRunService artRunService;
@@ -27,5 +37,23 @@ public class ArtRunController {
             @Valid @RequestBody ArtRunCreateReq request
     ) {
         return CommonResponse.success(artRunService.createArtRun(userId, request));
+    }
+
+    @GetMapping
+    @Operation(summary = "협동 러닝 세션 목록 조회", description = "커서 기반 페이지네이션으로 상태별 협동 러닝 세션 목록을 조회합니다. 로그인 필요")
+    public CommonResponse<ArtRunScrollRes> getAllArtRuns(
+            @RequestParam(defaultValue = "RECRUITING") ArtRunStatus status,
+            @RequestParam(required = false) Long cursor,
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size
+    ) {
+        return CommonResponse.success(artRunService.getAllArtRuns(status, cursor, size));
+    }
+
+    @GetMapping("/{sessionId}")
+    @Operation(summary = "협동 러닝 세션 상세 조회", description = "협동 러닝 세션 상세 정보를 조회합니다. 로그인 필요")
+    public CommonResponse<ArtRunDetailRes> getArtRunById(
+            @PathVariable Long sessionId
+    ) {
+        return CommonResponse.success(artRunService.getArtRunById(sessionId));
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/request/ArtRunCreateReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/request/ArtRunCreateReq.java
@@ -39,7 +39,6 @@ public class ArtRunCreateReq {
 
     @NotNull
     @Size(min = 2)
-    @Valid
     @Schema(description = "도안 좌표 (그리는 순서, 2개 이상)")
-    private List<CoordinateReq> coordinates;
+    private List<@NotNull @Valid CoordinateReq> coordinates;
 }

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunDetailRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunDetailRes.java
@@ -1,0 +1,80 @@
+package com._s3k.runsync.domain.artrun.dto.response;
+
+import com._s3k.runsync.entity.ArtRunSession;
+import com._s3k.runsync.entity.enums.ArtRunStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import org.locationtech.jts.geom.Coordinate;
+
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@Schema(description = "협동 러닝 세션 상세")
+public class ArtRunDetailRes {
+
+    @Schema(description = "세션 ID", example = "100")
+    private final Long sessionId;
+
+    @Schema(description = "모집 제목", example = "강아지런 같이 그려요")
+    private final String title;
+
+    @Schema(description = "세션 상태", example = "RECRUITING")
+    private final ArtRunStatus status;
+
+    @Schema(description = "호스트 정보")
+    private final ArtRunHostRes host;
+
+    @Schema(description = "도안 좌표")
+    private final List<CoordinateRes> coordinates;
+
+    @Schema(description = "정원", example = "5")
+    private final Integer capacity;
+
+    @Schema(description = "현재 참가 인원", example = "2")
+    private final Integer currentCount;
+
+    @Schema(description = "모이는 시간", example = "2026-06-10T07:00:00")
+    private final LocalDateTime meetingTime;
+
+    @Schema(description = "모이는 장소")
+    private final MeetingPlaceRes meetingPlace;
+
+    @Schema(description = "참가자 목록")
+    private final List<ParticipantRes> participants;
+
+    private ArtRunDetailRes(Long sessionId, String title, ArtRunStatus status, ArtRunHostRes host,
+                            List<CoordinateRes> coordinates, Integer capacity, Integer currentCount,
+                            LocalDateTime meetingTime, MeetingPlaceRes meetingPlace, List<ParticipantRes> participants) {
+        this.sessionId = sessionId;
+        this.title = title;
+        this.status = status;
+        this.host = host;
+        this.coordinates = coordinates;
+        this.capacity = capacity;
+        this.currentCount = currentCount;
+        this.meetingTime = meetingTime;
+        this.meetingPlace = meetingPlace;
+        this.participants = participants;
+    }
+
+    public static ArtRunDetailRes of(ArtRunSession session, int currentCount, List<ParticipantRes> participants) {
+        List<CoordinateRes> coordinates = Arrays.stream(session.getRoutePath().getCoordinates())
+                .map(c -> CoordinateRes.of(c.getY(), c.getX()))
+                .toList();
+
+        return new ArtRunDetailRes(
+                session.getId(),
+                session.getTitle(),
+                session.getStatus(),
+                ArtRunHostRes.of(session.getHost()),
+                coordinates,
+                session.getCapacity(),
+                currentCount,
+                session.getMeetingTime(),
+                MeetingPlaceRes.of(session),
+                participants
+        );
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunHostRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunHostRes.java
@@ -1,0 +1,25 @@
+package com._s3k.runsync.domain.artrun.dto.response;
+
+import com._s3k.runsync.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "호스트 정보")
+public class ArtRunHostRes {
+
+    @Schema(description = "호스트 사용자 ID", example = "1")
+    private final Long userId;
+
+    @Schema(description = "호스트 닉네임", example = "현우")
+    private final String nickname;
+
+    private ArtRunHostRes(Long userId, String nickname) {
+        this.userId = userId;
+        this.nickname = nickname;
+    }
+
+    public static ArtRunHostRes of(User host) {
+        return new ArtRunHostRes(host.getId(), host.getNickname());
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunRes.java
@@ -1,0 +1,62 @@
+package com._s3k.runsync.domain.artrun.dto.response;
+
+import com._s3k.runsync.entity.ArtRunSession;
+import com._s3k.runsync.entity.enums.ArtRunStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Schema(description = "협동 러닝 세션 목록 항목")
+public class ArtRunRes {
+
+    @Schema(description = "세션 ID", example = "100")
+    private final Long sessionId;
+
+    @Schema(description = "모집 제목", example = "강아지런 같이 그려요")
+    private final String title;
+
+    @Schema(description = "세션 상태", example = "RECRUITING")
+    private final ArtRunStatus status;
+
+    @Schema(description = "호스트 닉네임", example = "현우")
+    private final String hostNickname;
+
+    @Schema(description = "정원", example = "5")
+    private final Integer capacity;
+
+    @Schema(description = "현재 참가 인원", example = "2")
+    private final Integer currentCount;
+
+    @Schema(description = "모이는 시간", example = "2026-06-10T07:00:00")
+    private final LocalDateTime meetingTime;
+
+    @Schema(description = "모이는 장소 이름", example = "올림픽공원 평화의문 앞")
+    private final String meetingPlaceName;
+
+    private ArtRunRes(Long sessionId, String title, ArtRunStatus status, String hostNickname,
+                      Integer capacity, Integer currentCount, LocalDateTime meetingTime, String meetingPlaceName) {
+        this.sessionId = sessionId;
+        this.title = title;
+        this.status = status;
+        this.hostNickname = hostNickname;
+        this.capacity = capacity;
+        this.currentCount = currentCount;
+        this.meetingTime = meetingTime;
+        this.meetingPlaceName = meetingPlaceName;
+    }
+
+    public static ArtRunRes of(ArtRunSession session, int currentCount) {
+        return new ArtRunRes(
+                session.getId(),
+                session.getTitle(),
+                session.getStatus(),
+                session.getHost().getNickname(),
+                session.getCapacity(),
+                currentCount,
+                session.getMeetingTime(),
+                session.getMeetingPlaceName()
+        );
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunScrollRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunScrollRes.java
@@ -1,0 +1,33 @@
+package com._s3k.runsync.domain.artrun.dto.response;
+
+import com._s3k.runsync.global.common.ScrollPaginationCollection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Schema(description = "협동 러닝 세션 목록 응답")
+public class ArtRunScrollRes {
+
+    @Schema(description = "다음 페이지 존재 여부", example = "true")
+    private final boolean hasNext;
+
+    @Schema(description = "다음 요청에 사용할 커서 (마지막 sessionId)", example = "90")
+    private final Long nextCursor;
+
+    @Schema(description = "협동 러닝 세션 목록")
+    private final List<ArtRunRes> sessions;
+
+    private ArtRunScrollRes(boolean hasNext, Long nextCursor, List<ArtRunRes> sessions) {
+        this.hasNext = hasNext;
+        this.nextCursor = nextCursor;
+        this.sessions = sessions;
+    }
+
+    public static ArtRunScrollRes of(ScrollPaginationCollection<ArtRunRes> collection) {
+        List<ArtRunRes> contents = collection.getCurrentPageContents();
+        Long nextCursor = collection.hasNext() ? contents.get(contents.size() - 1).getSessionId() : null;
+        return new ArtRunScrollRes(collection.hasNext(), nextCursor, contents);
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/CoordinateRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/CoordinateRes.java
@@ -1,0 +1,24 @@
+package com._s3k.runsync.domain.artrun.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "좌표")
+public class CoordinateRes {
+
+    @Schema(description = "위도", example = "37.5210")
+    private final Double latitude;
+
+    @Schema(description = "경도", example = "127.1230")
+    private final Double longitude;
+
+    private CoordinateRes(Double latitude, Double longitude) {
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public static CoordinateRes of(double latitude, double longitude) {
+        return new CoordinateRes(latitude, longitude);
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/MeetingPlaceRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/MeetingPlaceRes.java
@@ -1,0 +1,33 @@
+package com._s3k.runsync.domain.artrun.dto.response;
+
+import com._s3k.runsync.entity.ArtRunSession;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "모이는 장소")
+public class MeetingPlaceRes {
+
+    @Schema(description = "장소 이름", example = "올림픽공원 평화의문 앞")
+    private final String name;
+
+    @Schema(description = "장소 위도", example = "37.5202")
+    private final Double latitude;
+
+    @Schema(description = "장소 경도", example = "127.1210")
+    private final Double longitude;
+
+    private MeetingPlaceRes(String name, Double latitude, Double longitude) {
+        this.name = name;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public static MeetingPlaceRes of(ArtRunSession session) {
+        return new MeetingPlaceRes(
+                session.getMeetingPlaceName(),
+                session.getMeetingPoint().getY(),
+                session.getMeetingPoint().getX()
+        );
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ParticipantRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ParticipantRes.java
@@ -1,0 +1,42 @@
+package com._s3k.runsync.domain.artrun.dto.response;
+
+import com._s3k.runsync.entity.ArtRunParticipant;
+import com._s3k.runsync.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Schema(description = "참가자")
+public class ParticipantRes {
+
+    @Schema(description = "참가자 사용자 ID", example = "1")
+    private final Long userId;
+
+    @Schema(description = "닉네임", example = "현우")
+    private final String nickname;
+
+    @Schema(description = "프로필 이미지", example = "https://sample.com/1.png")
+    private final String profileImage;
+
+    @Schema(description = "참가 시각", example = "2026-06-02T10:00:00")
+    private final LocalDateTime joinedAt;
+
+    private ParticipantRes(Long userId, String nickname, String profileImage, LocalDateTime joinedAt) {
+        this.userId = userId;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+        this.joinedAt = joinedAt;
+    }
+
+    public static ParticipantRes of(ArtRunParticipant participant) {
+        User user = participant.getUser();
+        return new ParticipantRes(
+                user.getId(),
+                user.getNickname(),
+                user.getProfileImage(),
+                participant.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/exception/ArtRunErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/exception/ArtRunErrorCode.java
@@ -1,0 +1,17 @@
+package com._s3k.runsync.domain.artrun.exception;
+
+import com._s3k.runsync.global.exception.ResultCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum ArtRunErrorCode implements ResultCode {
+
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, 5001, "협동 러닝 세션을 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunParticipantRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunParticipantRepository.java
@@ -2,6 +2,19 @@ package com._s3k.runsync.domain.artrun.repository;
 
 import com._s3k.runsync.entity.ArtRunParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface ArtRunParticipantRepository extends JpaRepository<ArtRunParticipant, Long> {
+
+    int countByArtRunSession_Id(Long artRunSessionId);
+
+    @Query("SELECT p.artRunSession.id AS sessionId, COUNT(p) AS participantCount " +
+            "FROM ArtRunParticipant p WHERE p.artRunSession.id IN :sessionIds GROUP BY p.artRunSession.id")
+    List<ParticipantCountProjection> countBySessionIds(@Param("sessionIds") List<Long> sessionIds);
+
+    @Query("SELECT p FROM ArtRunParticipant p JOIN FETCH p.user WHERE p.artRunSession.id = :sessionId ORDER BY p.id ASC")
+    List<ArtRunParticipant> findByArtRunSessionIdWithUser(@Param("sessionId") Long sessionId);
 }

--- a/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunParticipantRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunParticipantRepository.java
@@ -9,8 +9,6 @@ import java.util.List;
 
 public interface ArtRunParticipantRepository extends JpaRepository<ArtRunParticipant, Long> {
 
-    int countByArtRunSession_Id(Long artRunSessionId);
-
     @Query("SELECT p.artRunSession.id AS sessionId, COUNT(p) AS participantCount " +
             "FROM ArtRunParticipant p WHERE p.artRunSession.id IN :sessionIds GROUP BY p.artRunSession.id")
     List<ParticipantCountProjection> countBySessionIds(@Param("sessionIds") List<Long> sessionIds);

--- a/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunSessionRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunSessionRepository.java
@@ -1,7 +1,24 @@
 package com._s3k.runsync.domain.artrun.repository;
 
 import com._s3k.runsync.entity.ArtRunSession;
+import com._s3k.runsync.entity.enums.ArtRunStatus;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
 
 public interface ArtRunSessionRepository extends JpaRepository<ArtRunSession, Long> {
+
+    @Query("SELECT s FROM ArtRunSession s JOIN FETCH s.host WHERE s.status = :status ORDER BY s.id DESC")
+    List<ArtRunSession> findByStatusOrderByIdDesc(@Param("status") ArtRunStatus status, Pageable pageable);
+
+    @Query("SELECT s FROM ArtRunSession s JOIN FETCH s.host WHERE s.status = :status AND s.id < :cursor ORDER BY s.id DESC")
+    List<ArtRunSession> findByStatusAndIdLessThanOrderByIdDesc(@Param("status") ArtRunStatus status,
+                                                               @Param("cursor") Long cursor, Pageable pageable);
+
+    @Query("SELECT s FROM ArtRunSession s JOIN FETCH s.host WHERE s.id = :sessionId")
+    Optional<ArtRunSession> findByIdWithHost(@Param("sessionId") Long sessionId);
 }

--- a/src/main/java/com/_s3k/runsync/domain/artrun/repository/ParticipantCountProjection.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/repository/ParticipantCountProjection.java
@@ -1,0 +1,6 @@
+package com._s3k.runsync.domain.artrun.repository;
+
+public interface ParticipantCountProjection {
+    Long getSessionId();
+    Long getParticipantCount();
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
@@ -84,12 +84,11 @@ public class ArtRunService {
         ArtRunSession session = artRunSessionRepository.findByIdWithHost(sessionId)
                 .orElseThrow(() -> new GlobalException(ArtRunErrorCode.SESSION_NOT_FOUND));
 
-        int currentCount = artRunParticipantRepository.countByArtRunSession_Id(sessionId);
         List<ParticipantRes> participants = artRunParticipantRepository.findByArtRunSessionIdWithUser(sessionId).stream()
                 .map(ParticipantRes::of)
                 .toList();
 
-        return ArtRunDetailRes.of(session, currentCount, participants);
+        return ArtRunDetailRes.of(session, participants.size(), participants);
     }
 
     private Map<Long, Long> countParticipantsBySession(List<ArtRunSession> sessions) {

--- a/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
@@ -4,13 +4,21 @@ import com._s3k.runsync.domain.artrun.dto.request.ArtRunCreateReq;
 import com._s3k.runsync.domain.artrun.dto.request.CoordinateReq;
 import com._s3k.runsync.domain.artrun.dto.request.MeetingPlaceReq;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunCreateRes;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunDetailRes;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunRes;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunScrollRes;
+import com._s3k.runsync.domain.artrun.dto.response.ParticipantRes;
+import com._s3k.runsync.domain.artrun.exception.ArtRunErrorCode;
 import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
 import com._s3k.runsync.domain.artrun.repository.ArtRunSessionRepository;
+import com._s3k.runsync.domain.artrun.repository.ParticipantCountProjection;
 import com._s3k.runsync.domain.users.exception.UserErrorCode;
 import com._s3k.runsync.domain.users.repository.UserRepository;
 import com._s3k.runsync.entity.ArtRunParticipant;
 import com._s3k.runsync.entity.ArtRunSession;
 import com._s3k.runsync.entity.User;
+import com._s3k.runsync.entity.enums.ArtRunStatus;
+import com._s3k.runsync.global.common.ScrollPaginationCollection;
 import com._s3k.runsync.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.locationtech.jts.geom.Coordinate;
@@ -18,10 +26,13 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -52,6 +63,42 @@ public class ArtRunService {
         artRunParticipantRepository.save(ArtRunParticipant.of(session, host));
 
         return ArtRunCreateRes.of(session);
+    }
+
+    @Transactional(readOnly = true)
+    public ArtRunScrollRes getAllArtRuns(ArtRunStatus status, Long cursor, int size) {
+        List<ArtRunSession> sessions = cursor == null
+                ? artRunSessionRepository.findByStatusOrderByIdDesc(status, PageRequest.of(0, size + 1))
+                : artRunSessionRepository.findByStatusAndIdLessThanOrderByIdDesc(status, cursor, PageRequest.of(0, size + 1));
+
+        Map<Long, Long> countMap = countParticipantsBySession(sessions);
+        List<ArtRunRes> sessionResList = sessions.stream()
+                .map(session -> ArtRunRes.of(session, countMap.getOrDefault(session.getId(), 0L).intValue()))
+                .toList();
+
+        return ArtRunScrollRes.of(ScrollPaginationCollection.of(sessionResList, size));
+    }
+
+    @Transactional(readOnly = true)
+    public ArtRunDetailRes getArtRunById(Long sessionId) {
+        ArtRunSession session = artRunSessionRepository.findByIdWithHost(sessionId)
+                .orElseThrow(() -> new GlobalException(ArtRunErrorCode.SESSION_NOT_FOUND));
+
+        int currentCount = artRunParticipantRepository.countByArtRunSession_Id(sessionId);
+        List<ParticipantRes> participants = artRunParticipantRepository.findByArtRunSessionIdWithUser(sessionId).stream()
+                .map(ParticipantRes::of)
+                .toList();
+
+        return ArtRunDetailRes.of(session, currentCount, participants);
+    }
+
+    private Map<Long, Long> countParticipantsBySession(List<ArtRunSession> sessions) {
+        if (sessions.isEmpty()) {
+            return Map.of();
+        }
+        List<Long> sessionIds = sessions.stream().map(ArtRunSession::getId).toList();
+        return artRunParticipantRepository.countBySessionIds(sessionIds).stream()
+                .collect(Collectors.toMap(ParticipantCountProjection::getSessionId, ParticipantCountProjection::getParticipantCount));
     }
 
     private Point toPoint(double latitude, double longitude) {

--- a/src/main/java/com/_s3k/runsync/entity/ArtRunSession.java
+++ b/src/main/java/com/_s3k/runsync/entity/ArtRunSession.java
@@ -43,9 +43,6 @@ public class ArtRunSession extends BaseEntity {
     @Column(name = "route_path", columnDefinition = "geometry(LineString, 4326)", nullable = false)
     private LineString routePath;
 
-    @Column(name = "host_id", insertable = false, updatable = false)
-    private Long hostId;
-
     @Builder(access = AccessLevel.PRIVATE)
     private ArtRunSession(User host, String title, Integer capacity, LocalDateTime meetingTime,
                           String meetingPlaceName, Point meetingPoint, LineString routePath) {

--- a/src/main/java/com/_s3k/runsync/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/_s3k/runsync/global/exception/GlobalExceptionHandler.java
@@ -1,12 +1,15 @@
 package com._s3k.runsync.global.exception;
 
 import com._s3k.runsync.global.common.dto.CommonResponse;
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.ConstraintViolationException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
 
 @Slf4j
 @RestControllerAdvice
@@ -33,7 +36,7 @@ public class GlobalExceptionHandler {
             .body(new CommonResponse<>(GlobalErrorCode.INTERNAL_SERVER_ERROR));
     }
 
-    // Validation 실패 처리
+    // @Valid @RequestBody 검증 실패 처리
     @ExceptionHandler(MethodArgumentNotValidException.class)
     public ResponseEntity<CommonResponse<Void>> handleValidation(MethodArgumentNotValidException e) {
         String message = e.getBindingResult()
@@ -48,5 +51,31 @@ public class GlobalExceptionHandler {
         return ResponseEntity
             .status(GlobalErrorCode.VALIDATION_ERROR.getStatus())
             .body(new CommonResponse<>(GlobalErrorCode.VALIDATION_ERROR.getCode(), message));
+    }
+
+    // @Validated 파라미터(@RequestParam/@PathVariable) 검증 실패 처리
+    @ExceptionHandler(ConstraintViolationException.class)
+    public ResponseEntity<CommonResponse<Void>> handleConstraintViolation(ConstraintViolationException e) {
+        String message = e.getConstraintViolations()
+            .stream()
+            .findFirst()
+            .map(ConstraintViolation::getMessage)
+            .orElse(GlobalErrorCode.VALIDATION_ERROR.getMessage());
+
+        log.warn("Constraint violation: {}", message);
+
+        return ResponseEntity
+            .status(GlobalErrorCode.VALIDATION_ERROR.getStatus())
+            .body(new CommonResponse<>(GlobalErrorCode.VALIDATION_ERROR.getCode(), message));
+    }
+
+    // 요청 파라미터 타입 불일치(잘못된 enum 값 등) 처리
+    @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+    public ResponseEntity<CommonResponse<Void>> handleTypeMismatch(MethodArgumentTypeMismatchException e) {
+        log.warn("Type mismatch for parameter '{}': value={}", e.getName(), e.getValue());
+
+        return ResponseEntity
+            .status(GlobalErrorCode.VALIDATION_ERROR.getStatus())
+            .body(new CommonResponse<>(GlobalErrorCode.VALIDATION_ERROR));
     }
 }

--- a/src/test/java/com/_s3k/runsync/domain/artrun/dto/request/ArtRunCreateReqTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/artrun/dto/request/ArtRunCreateReqTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
 
@@ -56,6 +57,20 @@ class ArtRunCreateReqTest {
         Set<ConstraintViolation<ArtRunCreateReq>> violations = validator.validate(request);
 
         assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().equals("coordinates"));
+    }
+
+    @Test
+    @DisplayName("좌표 리스트에 null 원소가 있으면 검증에 실패한다")
+    void coordinates_nullElement() {
+        ArtRunCreateReq request = validRequest();
+        List<CoordinateReq> coordinates = new ArrayList<>();
+        coordinates.add(coord(37.5210, 127.1230));
+        coordinates.add(null);
+        ReflectionTestUtils.setField(request, "coordinates", coordinates);
+
+        Set<ConstraintViolation<ArtRunCreateReq>> violations = validator.validate(request);
+
+        assertThat(violations).anyMatch(v -> v.getPropertyPath().toString().contains("coordinates"));
     }
 
     @Test

--- a/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
@@ -140,7 +140,6 @@ class ArtRunServiceTest {
         // given
         ArtRunSession session = session(1L, "강아지런");
         given(artRunSessionRepository.findByIdWithHost(1L)).willReturn(Optional.of(session));
-        given(artRunParticipantRepository.countByArtRunSession_Id(1L)).willReturn(2);
         given(artRunParticipantRepository.findByArtRunSessionIdWithUser(1L))
                 .willReturn(List.of(participant(10L, "현우", session)));
 
@@ -154,7 +153,7 @@ class ArtRunServiceTest {
         assertThat(result.getCoordinates().get(0).getLatitude()).isEqualTo(37.5210);
         assertThat(result.getCoordinates().get(0).getLongitude()).isEqualTo(127.1230);
         assertThat(result.getMeetingPlace().getName()).isEqualTo("올림픽공원 평화의문 앞");
-        assertThat(result.getCurrentCount()).isEqualTo(2);
+        assertThat(result.getCurrentCount()).isEqualTo(1);
         assertThat(result.getParticipants()).hasSize(1);
         assertThat(result.getParticipants().get(0).getUserId()).isEqualTo(10L);
     }

--- a/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
@@ -3,8 +3,12 @@ package com._s3k.runsync.domain.artrun.service;
 import com._s3k.runsync.domain.artrun.dto.request.ArtRunCreateReq;
 import com._s3k.runsync.domain.artrun.dto.request.CoordinateReq;
 import com._s3k.runsync.domain.artrun.dto.request.MeetingPlaceReq;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunDetailRes;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunScrollRes;
+import com._s3k.runsync.domain.artrun.exception.ArtRunErrorCode;
 import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
 import com._s3k.runsync.domain.artrun.repository.ArtRunSessionRepository;
+import com._s3k.runsync.domain.artrun.repository.ParticipantCountProjection;
 import com._s3k.runsync.domain.users.exception.UserErrorCode;
 import com._s3k.runsync.domain.users.repository.UserRepository;
 import com._s3k.runsync.entity.ArtRunParticipant;
@@ -16,10 +20,16 @@ import com._s3k.runsync.global.exception.GlobalException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.LineString;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
@@ -30,11 +40,14 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class ArtRunServiceTest {
+
+    private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
 
     @InjectMocks
     private ArtRunService artRunService;
@@ -95,6 +108,96 @@ class ArtRunServiceTest {
 
         verify(artRunSessionRepository, never()).save(any());
         verify(artRunParticipantRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("세션 목록 조회 - size+1로 조회해 hasNext/nextCursor와 참가자 수가 매핑된다")
+    void getAllArtRuns_success() {
+        // given - size=1 이므로 size+1=2개 조회됨 (id DESC)
+        ArtRunSession session2 = session(2L, "고구마런");
+        ArtRunSession session1 = session(1L, "강아지런");
+        ParticipantCountProjection count2 = countProjection(2L, 3L);
+        ParticipantCountProjection count1 = countProjection(1L, 5L);
+        given(artRunSessionRepository.findByStatusOrderByIdDesc(any(), any(Pageable.class)))
+                .willReturn(List.of(session2, session1));
+        given(artRunParticipantRepository.countBySessionIds(any()))
+                .willReturn(List.of(count2, count1));
+
+        // when
+        ArtRunScrollRes result = artRunService.getAllArtRuns(ArtRunStatus.RECRUITING, null, 1);
+
+        // then
+        assertThat(result.isHasNext()).isTrue();
+        assertThat(result.getNextCursor()).isEqualTo(2L);          // 보여준 마지막(첫) 항목 id
+        assertThat(result.getSessions()).hasSize(1);
+        assertThat(result.getSessions().get(0).getSessionId()).isEqualTo(2L);
+        assertThat(result.getSessions().get(0).getCurrentCount()).isEqualTo(3); // projection 매핑
+    }
+
+    @Test
+    @DisplayName("세션 상세 조회 - host/좌표/모임장소/참가자가 응답에 포함된다")
+    void getArtRunById_success() {
+        // given
+        ArtRunSession session = session(1L, "강아지런");
+        given(artRunSessionRepository.findByIdWithHost(1L)).willReturn(Optional.of(session));
+        given(artRunParticipantRepository.countByArtRunSession_Id(1L)).willReturn(2);
+        given(artRunParticipantRepository.findByArtRunSessionIdWithUser(1L))
+                .willReturn(List.of(participant(10L, "현우", session)));
+
+        // when
+        ArtRunDetailRes result = artRunService.getArtRunById(1L);
+
+        // then
+        assertThat(result.getSessionId()).isEqualTo(1L);
+        assertThat(result.getHost().getUserId()).isEqualTo(1L);
+        assertThat(result.getCoordinates()).hasSize(2);
+        assertThat(result.getCoordinates().get(0).getLatitude()).isEqualTo(37.5210);
+        assertThat(result.getCoordinates().get(0).getLongitude()).isEqualTo(127.1230);
+        assertThat(result.getMeetingPlace().getName()).isEqualTo("올림픽공원 평화의문 앞");
+        assertThat(result.getCurrentCount()).isEqualTo(2);
+        assertThat(result.getParticipants()).hasSize(1);
+        assertThat(result.getParticipants().get(0).getUserId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 세션 상세 조회 시 예외 발생")
+    void getArtRunById_notFound() {
+        // given
+        given(artRunSessionRepository.findByIdWithHost(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.getArtRunById(1L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.SESSION_NOT_FOUND));
+    }
+
+    private ArtRunSession session(Long id, String title) {
+        User host = User.createTmpUser(Provider.KAKAO, "kakao" + id, "host" + id, null);
+        ReflectionTestUtils.setField(host, "id", id);
+
+        Point meetingPoint = GEOMETRY_FACTORY.createPoint(new Coordinate(127.1210, 37.5202));
+        LineString routePath = GEOMETRY_FACTORY.createLineString(new Coordinate[]{
+                new Coordinate(127.1230, 37.5210),
+                new Coordinate(127.1242, 37.5215)
+        });
+        ArtRunSession session = ArtRunSession.of(host, title, 5, LocalDateTime.now().plusDays(1),
+                "올림픽공원 평화의문 앞", meetingPoint, routePath);
+        ReflectionTestUtils.setField(session, "id", id);
+        return session;
+    }
+
+    private ArtRunParticipant participant(Long userId, String nickname, ArtRunSession session) {
+        User user = User.createTmpUser(Provider.KAKAO, "kakao" + userId, nickname, null);
+        ReflectionTestUtils.setField(user, "id", userId);
+        return ArtRunParticipant.of(session, user);
+    }
+
+    private ParticipantCountProjection countProjection(Long sessionId, Long count) {
+        ParticipantCountProjection projection = mock(ParticipantCountProjection.class);
+        given(projection.getSessionId()).willReturn(sessionId);
+        given(projection.getParticipantCount()).willReturn(count);
+        return projection;
     }
 
     private ArtRunCreateReq createRequest() {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #36 

## 📝작업 내용
 협동 러닝 세션 조회 API 구현했습니다.
- 세션 목록 조회 GET /api/art-runs (상태별 + 커서 페이지네이션)
- 세션 상세 조회 GET /api/art-runs/{sessionId}
- 목록 참가자 수는 그룹 쿼리로 한 번에 가져와서 N+1 방지
- 파라미터 검증 / 잘못된 status 값 예외 처리 추가

## 📷스크린샷 (선택)
<img width="1430" height="630" alt="스크린샷 2026-06-03 오후 2 55 04" src="https://github.com/user-attachments/assets/3524b111-906e-40f6-8757-0b93d02b657a" />
<img width="1413" height="580" alt="스크린샷 2026-06-03 오후 2 55 09" src="https://github.com/user-attachments/assets/17eba079-3712-48f1-bf20-a65378d841bf" />
<img width="1446" height="488" alt="스크린샷 2026-06-03 오후 1 53 38" src="https://github.com/user-attachments/assets/eb0f86f2-0c7a-49e8-ba0f-8208a8f42c88" />
<img width="1428" height="831" alt="스크린샷 2026-06-03 오후 1 53 43" src="https://github.com/user-attachments/assets/5e988bde-d4e2-41c3-8efb-77cefb3c21fc" />
