### PR TITLE
[Feat] 협동 러닝 세션 참가/취소 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/artrun/controller/ArtRunController.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/controller/ArtRunController.java
@@ -14,6 +14,7 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -55,5 +56,25 @@ public class ArtRunController {
             @PathVariable Long sessionId
     ) {
         return CommonResponse.success(artRunService.getArtRunById(sessionId));
+    }
+
+    @PostMapping("/{sessionId}/participants")
+    @Operation(summary = "협동 러닝 세션 참가", description = "협동 러닝 세션에 참가합니다(신청 즉시 입장). 모집 중인 세션만 가능. 로그인 필요")
+    public CommonResponse<Void> joinArtRun(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long sessionId
+    ) {
+        artRunService.joinArtRun(userId, sessionId);
+        return CommonResponse.success(null);
+    }
+
+    @DeleteMapping("/{sessionId}/participants/me")
+    @Operation(summary = "협동 러닝 세션 참가 취소", description = "본인의 협동 러닝 세션 참가를 취소합니다. 호스트는 취소할 수 없습니다. 로그인 필요")
+    public CommonResponse<Void> leaveArtRun(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long sessionId
+    ) {
+        artRunService.leaveArtRun(userId, sessionId);
+        return CommonResponse.success(null);
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/artrun/exception/ArtRunErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/exception/ArtRunErrorCode.java
@@ -9,7 +9,12 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor
 public enum ArtRunErrorCode implements ResultCode {
 
-    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, 5001, "협동 러닝 세션을 찾을 수 없습니다.");
+    SESSION_NOT_FOUND(HttpStatus.NOT_FOUND, 5001, "협동 러닝 세션을 찾을 수 없습니다."),
+    NOT_RECRUITING(HttpStatus.CONFLICT, 5002, "모집 중인 세션이 아닙니다."),
+    SESSION_FULL(HttpStatus.CONFLICT, 5003, "정원이 가득 찼습니다."),
+    ALREADY_JOINED(HttpStatus.CONFLICT, 5004, "이미 참가한 세션입니다."),
+    NOT_PARTICIPANT(HttpStatus.NOT_FOUND, 5005, "참가 중인 세션이 아닙니다."),
+    HOST_CANNOT_LEAVE(HttpStatus.CONFLICT, 5006, "호스트는 참가를 취소할 수 없습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunParticipantRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunParticipantRepository.java
@@ -6,8 +6,15 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface ArtRunParticipantRepository extends JpaRepository<ArtRunParticipant, Long> {
+
+    boolean existsByArtRunSession_IdAndUser_Id(Long artRunSessionId, Long userId);
+
+    int countByArtRunSession_Id(Long artRunSessionId);
+
+    Optional<ArtRunParticipant> findByArtRunSession_IdAndUser_Id(Long artRunSessionId, Long userId);
 
     @Query("SELECT p.artRunSession.id AS sessionId, COUNT(p) AS participantCount " +
             "FROM ArtRunParticipant p WHERE p.artRunSession.id IN :sessionIds GROUP BY p.artRunSession.id")

--- a/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunSessionRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunSessionRepository.java
@@ -2,8 +2,10 @@ package com._s3k.runsync.domain.artrun.repository;
 
 import com._s3k.runsync.entity.ArtRunSession;
 import com._s3k.runsync.entity.enums.ArtRunStatus;
+import jakarta.persistence.LockModeType;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -21,4 +23,8 @@ public interface ArtRunSessionRepository extends JpaRepository<ArtRunSession, Lo
 
     @Query("SELECT s FROM ArtRunSession s JOIN FETCH s.host WHERE s.id = :sessionId")
     Optional<ArtRunSession> findByIdWithHost(@Param("sessionId") Long sessionId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("SELECT s FROM ArtRunSession s WHERE s.id = :sessionId")
+    Optional<ArtRunSession> findByIdWithLock(@Param("sessionId") Long sessionId);
 }

--- a/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
@@ -91,6 +91,43 @@ public class ArtRunService {
         return ArtRunDetailRes.of(session, participants.size(), participants);
     }
 
+    @Transactional
+    public void joinArtRun(Long userId, Long sessionId) {
+        ArtRunSession session = artRunSessionRepository.findByIdWithLock(sessionId)
+                .orElseThrow(() -> new GlobalException(ArtRunErrorCode.SESSION_NOT_FOUND));
+
+        if (!session.isRecruiting()) {
+            throw new GlobalException(ArtRunErrorCode.NOT_RECRUITING);
+        }
+        if (artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(sessionId, userId)) {
+            throw new GlobalException(ArtRunErrorCode.ALREADY_JOINED);
+        }
+        if (session.isFull(artRunParticipantRepository.countByArtRunSession_Id(sessionId))) {
+            throw new GlobalException(ArtRunErrorCode.SESSION_FULL);
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
+        artRunParticipantRepository.save(ArtRunParticipant.of(session, user));
+    }
+
+    @Transactional
+    public void leaveArtRun(Long userId, Long sessionId) {
+        ArtRunSession session = artRunSessionRepository.findByIdWithHost(sessionId)
+                .orElseThrow(() -> new GlobalException(ArtRunErrorCode.SESSION_NOT_FOUND));
+
+        if (!session.isRecruiting()) {
+            throw new GlobalException(ArtRunErrorCode.NOT_RECRUITING);
+        }
+        if (session.isHost(userId)) {
+            throw new GlobalException(ArtRunErrorCode.HOST_CANNOT_LEAVE);
+        }
+
+        ArtRunParticipant participant = artRunParticipantRepository.findByArtRunSession_IdAndUser_Id(sessionId, userId)
+                .orElseThrow(() -> new GlobalException(ArtRunErrorCode.NOT_PARTICIPANT));
+        artRunParticipantRepository.delete(participant);
+    }
+
     private Map<Long, Long> countParticipantsBySession(List<ArtRunSession> sessions) {
         if (sessions.isEmpty()) {
             return Map.of();

--- a/src/main/java/com/_s3k/runsync/entity/ArtRunSession.java
+++ b/src/main/java/com/_s3k/runsync/entity/ArtRunSession.java
@@ -68,4 +68,16 @@ public class ArtRunSession extends BaseEntity {
                 .routePath(routePath)
                 .build();
     }
+
+    public boolean isRecruiting() {
+        return this.status == ArtRunStatus.RECRUITING;
+    }
+
+    public boolean isFull(int currentCount) {
+        return currentCount >= this.capacity;
+    }
+
+    public boolean isHost(Long userId) {
+        return this.host.getId().equals(userId);
+    }
 }

--- a/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
@@ -171,6 +171,137 @@ class ArtRunServiceTest {
                         .isEqualTo(ArtRunErrorCode.SESSION_NOT_FOUND));
     }
 
+    @Test
+    @DisplayName("세션 참가 성공 - 모집중이고 정원 여유가 있으면 참가자가 저장된다")
+    void joinArtRun_success() {
+        // given
+        ArtRunSession session = session(1L, "강아지런"); // capacity 5, RECRUITING, host id=1
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.of(session));
+        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(1L, 10L)).willReturn(false);
+        given(artRunParticipantRepository.countByArtRunSession_Id(1L)).willReturn(2);
+        User user = User.createTmpUser(Provider.KAKAO, "kakao10", "현우", null);
+        ReflectionTestUtils.setField(user, "id", 10L);
+        given(userRepository.findById(10L)).willReturn(Optional.of(user));
+
+        // when
+        artRunService.joinArtRun(10L, 1L);
+
+        // then
+        ArgumentCaptor<ArtRunParticipant> captor = ArgumentCaptor.forClass(ArtRunParticipant.class);
+        verify(artRunParticipantRepository).save(captor.capture());
+        assertThat(captor.getValue().getUser()).isEqualTo(user);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 세션 참가 시 예외 발생")
+    void joinArtRun_sessionNotFound() {
+        // given
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.joinArtRun(10L, 1L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.SESSION_NOT_FOUND));
+        verify(artRunParticipantRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("모집중이 아닌 세션 참가 시 예외 발생")
+    void joinArtRun_notRecruiting() {
+        // given
+        ArtRunSession session = session(1L, "강아지런");
+        ReflectionTestUtils.setField(session, "status", ArtRunStatus.IN_PROGRESS);
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.of(session));
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.joinArtRun(10L, 1L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.NOT_RECRUITING));
+        verify(artRunParticipantRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("이미 참가한 세션에 다시 참가 시 예외 발생")
+    void joinArtRun_alreadyJoined() {
+        // given
+        ArtRunSession session = session(1L, "강아지런");
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.of(session));
+        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(1L, 10L)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.joinArtRun(10L, 1L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.ALREADY_JOINED));
+        verify(artRunParticipantRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("정원이 가득 찬 세션 참가 시 예외 발생")
+    void joinArtRun_full() {
+        // given - capacity 5, 이미 5명
+        ArtRunSession session = session(1L, "강아지런");
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.of(session));
+        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(1L, 10L)).willReturn(false);
+        given(artRunParticipantRepository.countByArtRunSession_Id(1L)).willReturn(5);
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.joinArtRun(10L, 1L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.SESSION_FULL));
+        verify(artRunParticipantRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("세션 참가 취소 성공 - 참가자가 삭제된다")
+    void leaveArtRun_success() {
+        // given - host id=1, 취소 요청자는 10L
+        ArtRunSession session = session(1L, "강아지런");
+        ArtRunParticipant participant = participant(10L, "현우", session);
+        given(artRunSessionRepository.findByIdWithHost(1L)).willReturn(Optional.of(session));
+        given(artRunParticipantRepository.findByArtRunSession_IdAndUser_Id(1L, 10L)).willReturn(Optional.of(participant));
+
+        // when
+        artRunService.leaveArtRun(10L, 1L);
+
+        // then
+        verify(artRunParticipantRepository).delete(participant);
+    }
+
+    @Test
+    @DisplayName("호스트가 참가 취소 시 예외 발생")
+    void leaveArtRun_hostCannotLeave() {
+        // given - host id=1, 취소 요청자도 1L
+        ArtRunSession session = session(1L, "강아지런");
+        given(artRunSessionRepository.findByIdWithHost(1L)).willReturn(Optional.of(session));
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.leaveArtRun(1L, 1L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.HOST_CANNOT_LEAVE));
+        verify(artRunParticipantRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("참가하지 않은 세션 취소 시 예외 발생")
+    void leaveArtRun_notParticipant() {
+        // given - host id=1, 요청자 10L은 미참가
+        ArtRunSession session = session(1L, "강아지런");
+        given(artRunSessionRepository.findByIdWithHost(1L)).willReturn(Optional.of(session));
+        given(artRunParticipantRepository.findByArtRunSession_IdAndUser_Id(1L, 10L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.leaveArtRun(10L, 1L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.NOT_PARTICIPANT));
+        verify(artRunParticipantRepository, never()).delete(any());
+    }
+
     private ArtRunSession session(Long id, String title) {
         User host = User.createTmpUser(Provider.KAKAO, "kakao" + id, "host" + id, null);
         ReflectionTestUtils.setField(host, "id", id);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #37 

## 📝작업 내용
협동 러닝 세션 참가/취소 API 구현했습니다.

- 세션 참가 POST /api/art-runs/{sessionId}/participants (신청 즉시 입장)
- 세션 참가 취소 DELETE /api/art-runs/{sessionId}/participants/me
- 모집중(RECRUITING) 상태에서만 참가/취소 가능, 호스트는 취소 불가
- 동시 참가 정원 초과는 비관적 락으로 방지
- 참가/취소 단위 테스트 추가

## 📷스크린샷
<img width="1238" height="1117" alt="스크린샷 2026-06-03 오후 6 28 43" src="https://github.com/user-attachments/assets/384cd10f-34e7-47a4-9dfc-301ee6c9b4f7" />

<img width="1229" height="1133" alt="스크린샷 2026-06-03 오후 6 28 25" src="https://github.com/user-attachments/assets/7f20de6e-89d5-4919-aaea-d5d7990cc2d8" />
<img width="1237" height="1115" alt="스크린샷 2026-06-03 오후 6 29 00" src="https://github.com/user-attachments/assets/95be4d55-7cf5-4df0-bd09-4cfcbebdb7db" />
<img width="1244" height="960" alt="스크린샷 2026-06-03 오후 6 43 35" src="https://github.com/user-attachments/assets/aea7f045-fba0-4f12-bba4-339d5cd29e0f" />
