### PR TITLE
[Feat] 협동 러닝 세션 상태 변경·삭제 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/artrun/controller/ArtRunController.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/controller/ArtRunController.java
@@ -1,9 +1,11 @@
 package com._s3k.runsync.domain.artrun.controller;
 
 import com._s3k.runsync.domain.artrun.dto.request.ArtRunCreateReq;
+import com._s3k.runsync.domain.artrun.dto.request.ArtRunStatusUpdateReq;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunCreateRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunDetailRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunScrollRes;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunStatusRes;
 import com._s3k.runsync.domain.artrun.service.ArtRunService;
 import com._s3k.runsync.entity.enums.ArtRunStatus;
 import com._s3k.runsync.global.common.dto.CommonResponse;
@@ -16,6 +18,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -75,6 +78,26 @@ public class ArtRunController {
             @PathVariable Long sessionId
     ) {
         artRunService.leaveArtRun(userId, sessionId);
+        return CommonResponse.success(null);
+    }
+
+    @PatchMapping("/{sessionId}")
+    @Operation(summary = "협동 러닝 세션 상태 변경", description = "호스트가 세션을 시작/종료합니다. RECRUITING→IN_PROGRESS→COMPLETED 순서. 로그인 필요")
+    public CommonResponse<ArtRunStatusRes> updateArtRunStatus(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long sessionId,
+            @Valid @RequestBody ArtRunStatusUpdateReq request
+    ) {
+        return CommonResponse.success(artRunService.updateArtRunStatus(userId, sessionId, request));
+    }
+
+    @DeleteMapping("/{sessionId}")
+    @Operation(summary = "협동 러닝 세션 삭제", description = "호스트가 모집 중인 세션을 삭제합니다. 로그인 필요")
+    public CommonResponse<Void> deleteArtRun(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long sessionId
+    ) {
+        artRunService.deleteArtRun(userId, sessionId);
         return CommonResponse.success(null);
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/request/ArtRunStatusUpdateReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/request/ArtRunStatusUpdateReq.java
@@ -1,0 +1,17 @@
+package com._s3k.runsync.domain.artrun.dto.request;
+
+import com._s3k.runsync.entity.enums.ArtRunStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+@Schema(description = "협동 러닝 세션 상태 변경 요청")
+public class ArtRunStatusUpdateReq {
+
+    @NotNull
+    @Schema(description = "변경할 상태 (IN_PROGRESS: 시작, COMPLETED: 종료)", example = "IN_PROGRESS")
+    private ArtRunStatus status;
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunStatusRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunStatusRes.java
@@ -1,0 +1,26 @@
+package com._s3k.runsync.domain.artrun.dto.response;
+
+import com._s3k.runsync.entity.ArtRunSession;
+import com._s3k.runsync.entity.enums.ArtRunStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "협동 러닝 세션 상태 변경 응답")
+public class ArtRunStatusRes {
+
+    @Schema(description = "세션 ID", example = "100")
+    private final Long sessionId;
+
+    @Schema(description = "변경된 세션 상태", example = "IN_PROGRESS")
+    private final ArtRunStatus status;
+
+    private ArtRunStatusRes(Long sessionId, ArtRunStatus status) {
+        this.sessionId = sessionId;
+        this.status = status;
+    }
+
+    public static ArtRunStatusRes of(ArtRunSession session) {
+        return new ArtRunStatusRes(session.getId(), session.getStatus());
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/exception/ArtRunErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/exception/ArtRunErrorCode.java
@@ -14,7 +14,9 @@ public enum ArtRunErrorCode implements ResultCode {
     SESSION_FULL(HttpStatus.CONFLICT, 5003, "정원이 가득 찼습니다."),
     ALREADY_JOINED(HttpStatus.CONFLICT, 5004, "이미 참가한 세션입니다."),
     NOT_PARTICIPANT(HttpStatus.NOT_FOUND, 5005, "참가 중인 세션이 아닙니다."),
-    HOST_CANNOT_LEAVE(HttpStatus.CONFLICT, 5006, "호스트는 참가를 취소할 수 없습니다.");
+    HOST_CANNOT_LEAVE(HttpStatus.CONFLICT, 5006, "호스트는 참가를 취소할 수 없습니다."),
+    NOT_HOST(HttpStatus.FORBIDDEN, 5007, "호스트만 가능한 작업입니다."),
+    INVALID_STATUS_TRANSITION(HttpStatus.CONFLICT, 5008, "잘못된 상태 변경입니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunParticipantRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunParticipantRepository.java
@@ -2,6 +2,7 @@ package com._s3k.runsync.domain.artrun.repository;
 
 import com._s3k.runsync.entity.ArtRunParticipant;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,7 +17,9 @@ public interface ArtRunParticipantRepository extends JpaRepository<ArtRunPartici
 
     Optional<ArtRunParticipant> findByArtRunSession_IdAndUser_Id(Long artRunSessionId, Long userId);
 
-    void deleteByArtRunSession_Id(Long artRunSessionId);
+    @Modifying
+    @Query("DELETE FROM ArtRunParticipant p WHERE p.artRunSession.id = :artRunSessionId")
+    void deleteByArtRunSession_Id(@Param("artRunSessionId") Long artRunSessionId);
 
     @Query("SELECT p.artRunSession.id AS sessionId, COUNT(p) AS participantCount " +
             "FROM ArtRunParticipant p WHERE p.artRunSession.id IN :sessionIds GROUP BY p.artRunSession.id")

--- a/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunParticipantRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/repository/ArtRunParticipantRepository.java
@@ -16,6 +16,8 @@ public interface ArtRunParticipantRepository extends JpaRepository<ArtRunPartici
 
     Optional<ArtRunParticipant> findByArtRunSession_IdAndUser_Id(Long artRunSessionId, Long userId);
 
+    void deleteByArtRunSession_Id(Long artRunSessionId);
+
     @Query("SELECT p.artRunSession.id AS sessionId, COUNT(p) AS participantCount " +
             "FROM ArtRunParticipant p WHERE p.artRunSession.id IN :sessionIds GROUP BY p.artRunSession.id")
     List<ParticipantCountProjection> countBySessionIds(@Param("sessionIds") List<Long> sessionIds);

--- a/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
@@ -1,12 +1,14 @@
 package com._s3k.runsync.domain.artrun.service;
 
 import com._s3k.runsync.domain.artrun.dto.request.ArtRunCreateReq;
+import com._s3k.runsync.domain.artrun.dto.request.ArtRunStatusUpdateReq;
 import com._s3k.runsync.domain.artrun.dto.request.CoordinateReq;
 import com._s3k.runsync.domain.artrun.dto.request.MeetingPlaceReq;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunCreateRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunDetailRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunScrollRes;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunStatusRes;
 import com._s3k.runsync.domain.artrun.dto.response.ParticipantRes;
 import com._s3k.runsync.domain.artrun.exception.ArtRunErrorCode;
 import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
@@ -126,6 +128,35 @@ public class ArtRunService {
         ArtRunParticipant participant = artRunParticipantRepository.findByArtRunSession_IdAndUser_Id(sessionId, userId)
                 .orElseThrow(() -> new GlobalException(ArtRunErrorCode.NOT_PARTICIPANT));
         artRunParticipantRepository.delete(participant);
+    }
+
+    @Transactional
+    public ArtRunStatusRes updateArtRunStatus(Long userId, Long sessionId, ArtRunStatusUpdateReq request) {
+        ArtRunSession session = artRunSessionRepository.findByIdWithLock(sessionId)
+                .orElseThrow(() -> new GlobalException(ArtRunErrorCode.SESSION_NOT_FOUND));
+        session.validateHost(userId);
+
+        switch (request.getStatus()) {
+            case IN_PROGRESS -> session.start();
+            case COMPLETED -> session.complete();
+            default -> throw new GlobalException(ArtRunErrorCode.INVALID_STATUS_TRANSITION);
+        }
+
+        return ArtRunStatusRes.of(session);
+    }
+
+    @Transactional
+    public void deleteArtRun(Long userId, Long sessionId) {
+        ArtRunSession session = artRunSessionRepository.findByIdWithLock(sessionId)
+                .orElseThrow(() -> new GlobalException(ArtRunErrorCode.SESSION_NOT_FOUND));
+        session.validateHost(userId);
+
+        if (!session.isRecruiting()) {
+            throw new GlobalException(ArtRunErrorCode.NOT_RECRUITING);
+        }
+
+        artRunParticipantRepository.deleteByArtRunSession_Id(sessionId);
+        artRunSessionRepository.delete(session);
     }
 
     private Map<Long, Long> countParticipantsBySession(List<ArtRunSession> sessions) {

--- a/src/main/java/com/_s3k/runsync/entity/ArtRunSession.java
+++ b/src/main/java/com/_s3k/runsync/entity/ArtRunSession.java
@@ -1,6 +1,8 @@
 package com._s3k.runsync.entity;
 
+import com._s3k.runsync.domain.artrun.exception.ArtRunErrorCode;
 import com._s3k.runsync.entity.enums.ArtRunStatus;
+import com._s3k.runsync.global.exception.GlobalException;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -79,5 +81,25 @@ public class ArtRunSession extends BaseEntity {
 
     public boolean isHost(Long userId) {
         return this.host.getId().equals(userId);
+    }
+
+    public void start() {
+        if (this.status != ArtRunStatus.RECRUITING) {
+            throw new GlobalException(ArtRunErrorCode.INVALID_STATUS_TRANSITION);
+        }
+        this.status = ArtRunStatus.IN_PROGRESS;
+    }
+
+    public void complete() {
+        if (this.status != ArtRunStatus.IN_PROGRESS) {
+            throw new GlobalException(ArtRunErrorCode.INVALID_STATUS_TRANSITION);
+        }
+        this.status = ArtRunStatus.COMPLETED;
+    }
+
+    public void validateHost(Long userId) {
+        if (!isHost(userId)) {
+            throw new GlobalException(ArtRunErrorCode.NOT_HOST);
+        }
     }
 }

--- a/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
@@ -1,10 +1,12 @@
 package com._s3k.runsync.domain.artrun.service;
 
 import com._s3k.runsync.domain.artrun.dto.request.ArtRunCreateReq;
+import com._s3k.runsync.domain.artrun.dto.request.ArtRunStatusUpdateReq;
 import com._s3k.runsync.domain.artrun.dto.request.CoordinateReq;
 import com._s3k.runsync.domain.artrun.dto.request.MeetingPlaceReq;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunDetailRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunScrollRes;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunStatusRes;
 import com._s3k.runsync.domain.artrun.exception.ArtRunErrorCode;
 import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
 import com._s3k.runsync.domain.artrun.repository.ArtRunSessionRepository;
@@ -300,6 +302,143 @@ class ArtRunServiceTest {
                 .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
                         .isEqualTo(ArtRunErrorCode.NOT_PARTICIPANT));
         verify(artRunParticipantRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("세션 상태 변경 - 호스트가 모집중 세션을 시작하면 IN_PROGRESS가 된다")
+    void updateArtRunStatus_start_success() {
+        // given - RECRUITING, host id=1
+        ArtRunSession session = session(1L, "강아지런");
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.of(session));
+
+        // when
+        ArtRunStatusRes result = artRunService.updateArtRunStatus(1L, 1L, statusReq(ArtRunStatus.IN_PROGRESS));
+
+        // then
+        assertThat(result.getStatus()).isEqualTo(ArtRunStatus.IN_PROGRESS);
+        assertThat(session.getStatus()).isEqualTo(ArtRunStatus.IN_PROGRESS);
+    }
+
+    @Test
+    @DisplayName("세션 상태 변경 - 호스트가 진행중 세션을 종료하면 COMPLETED가 된다")
+    void updateArtRunStatus_complete_success() {
+        // given - IN_PROGRESS, host id=1
+        ArtRunSession session = session(1L, "강아지런");
+        ReflectionTestUtils.setField(session, "status", ArtRunStatus.IN_PROGRESS);
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.of(session));
+
+        // when
+        ArtRunStatusRes result = artRunService.updateArtRunStatus(1L, 1L, statusReq(ArtRunStatus.COMPLETED));
+
+        // then
+        assertThat(result.getStatus()).isEqualTo(ArtRunStatus.COMPLETED);
+    }
+
+    @Test
+    @DisplayName("호스트가 아닌 유저가 상태 변경 시 예외 발생")
+    void updateArtRunStatus_notHost() {
+        // given - host id=1, 요청자 99L
+        ArtRunSession session = session(1L, "강아지런");
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.of(session));
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.updateArtRunStatus(99L, 1L, statusReq(ArtRunStatus.IN_PROGRESS)))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.NOT_HOST));
+    }
+
+    @Test
+    @DisplayName("잘못된 상태 전이(모집중→완료) 시 예외 발생")
+    void updateArtRunStatus_invalidTransition() {
+        // given - RECRUITING 상태에서 곧바로 COMPLETED 요청
+        ArtRunSession session = session(1L, "강아지런");
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.of(session));
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.updateArtRunStatus(1L, 1L, statusReq(ArtRunStatus.COMPLETED)))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.INVALID_STATUS_TRANSITION));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 세션 상태 변경 시 예외 발생")
+    void updateArtRunStatus_sessionNotFound() {
+        // given
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.updateArtRunStatus(1L, 1L, statusReq(ArtRunStatus.IN_PROGRESS)))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.SESSION_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("세션 삭제 성공 - 호스트가 모집중 세션을 삭제하면 참가자도 함께 삭제된다")
+    void deleteArtRun_success() {
+        // given - RECRUITING, host id=1
+        ArtRunSession session = session(1L, "강아지런");
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.of(session));
+
+        // when
+        artRunService.deleteArtRun(1L, 1L);
+
+        // then
+        verify(artRunParticipantRepository).deleteByArtRunSession_Id(1L);
+        verify(artRunSessionRepository).delete(session);
+    }
+
+    @Test
+    @DisplayName("호스트가 아닌 유저가 세션 삭제 시 예외 발생")
+    void deleteArtRun_notHost() {
+        // given - host id=1, 요청자 99L
+        ArtRunSession session = session(1L, "강아지런");
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.of(session));
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.deleteArtRun(99L, 1L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.NOT_HOST));
+        verify(artRunSessionRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("모집중이 아닌 세션 삭제 시 예외 발생")
+    void deleteArtRun_notRecruiting() {
+        // given - IN_PROGRESS
+        ArtRunSession session = session(1L, "강아지런");
+        ReflectionTestUtils.setField(session, "status", ArtRunStatus.IN_PROGRESS);
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.of(session));
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.deleteArtRun(1L, 1L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.NOT_RECRUITING));
+        verify(artRunParticipantRepository, never()).deleteByArtRunSession_Id(any());
+        verify(artRunSessionRepository, never()).delete(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 세션 삭제 시 예외 발생")
+    void deleteArtRun_sessionNotFound() {
+        // given
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.deleteArtRun(1L, 1L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.SESSION_NOT_FOUND));
+    }
+
+    private ArtRunStatusUpdateReq statusReq(ArtRunStatus status) {
+        ArtRunStatusUpdateReq request = new ArtRunStatusUpdateReq();
+        ReflectionTestUtils.setField(request, "status", status);
+        return request;
     }
 
     private ArtRunSession session(Long id, String title) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #38 

## 📝작업 내용

협동 러닝 세션 상태 변경/삭제 API 구현했습니다.
- 호스트가 세션 시작/종료(PATCH) + 삭제(DELETE)
- 상태 전이 검증, 동시성 락 처리

## 📷스크린샷

<img width="1247" height="551" alt="스크린샷 2026-06-03 오후 8 52 07" src="https://github.com/user-attachments/assets/45f43ee8-3cb5-4a47-a7e8-df09e40bfebd" />
<img width="1238" height="815" alt="스크린샷 2026-06-03 오후 8 52 03" src="https://github.com/user-attachments/assets/676ef56a-816b-42d2-92da-b75ab00232a1" />
<img width="1235" height="553" alt="스크린샷 2026-06-03 오후 8 51 26" src="https://github.com/user-attachments/assets/af695305-cbc3-4b22-86fb-fd58984c9198" />
<img width="1245" height="819" alt="스크린샷 2026-06-03 오후 8 51 20" src="https://github.com/user-attachments/assets/3effd2e8-bf70-48b9-bb05-fbd86c6d0f31" />