### PR TITLE
[Feat] 협동 러닝 실시간 위치 공유 WebSocket 확장

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunLocationRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunLocationRes.java
@@ -1,0 +1,28 @@
+package com._s3k.runsync.domain.artrun.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "협동 러닝 참가자 위치")
+public class ArtRunLocationRes {
+
+    @Schema(description = "참가자 유저 ID", example = "10")
+    private final Long userId;
+
+    @Schema(description = "위도", example = "37.5665")
+    private final Double latitude;
+
+    @Schema(description = "경도", example = "126.9780")
+    private final Double longitude;
+
+    private ArtRunLocationRes(Long userId, Double latitude, Double longitude) {
+        this.userId = userId;
+        this.latitude = latitude;
+        this.longitude = longitude;
+    }
+
+    public static ArtRunLocationRes of(Long userId, Double latitude, Double longitude) {
+        return new ArtRunLocationRes(userId, latitude, longitude);
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
@@ -159,6 +159,11 @@ public class ArtRunService {
         artRunSessionRepository.delete(session);
     }
 
+    @Transactional(readOnly = true)
+    public boolean isParticipant(Long userId, Long sessionId) {
+        return artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(sessionId, userId);
+    }
+
     private Map<Long, Long> countParticipantsBySession(List<ArtRunSession> sessions) {
         if (sessions.isEmpty()) {
             return Map.of();

--- a/src/main/java/com/_s3k/runsync/domain/location/dto/request/LocationUpdateReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/dto/request/LocationUpdateReq.java
@@ -12,6 +12,9 @@ public class LocationUpdateReq {
     @Schema(description = "러닝 세션 ID", example = "1")
     private Long sessionId;
 
+    @Schema(description = "협동 러닝 세션 ID (협동 러닝 위치 공유 시)", example = "100")
+    private Long artRunSessionId;
+
     @Schema(description = "위도", example = "37.5665")
     private Double latitude;
 

--- a/src/main/java/com/_s3k/runsync/domain/location/handler/LocationMessageHandler.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/handler/LocationMessageHandler.java
@@ -1,5 +1,7 @@
 package com._s3k.runsync.domain.location.handler;
 
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunLocationRes;
+import com._s3k.runsync.domain.artrun.service.ArtRunService;
 import com._s3k.runsync.domain.run.service.RunSessionService;
 import com._s3k.runsync.global.exception.GlobalException;
 import com._s3k.runsync.global.websocket.dto.WebSocketMessage;
@@ -22,6 +24,7 @@ public class LocationMessageHandler {
     private final SimpMessagingTemplate messagingTemplate;
     private final LocationService locationService;
     private final RunSessionService runSessionService;
+    private final ArtRunService artRunService;
 
     @MessageMapping("/location")
     public void handleLocation(WebSocketMessage<LocationUpdateReq> message, Principal principal) {
@@ -43,6 +46,13 @@ public class LocationMessageHandler {
                 "/topic/location/" + userId,
                 WebSocketMessage.of("FRIEND_LOCATION_UPDATE", FriendLocationRes.of(userId, data.getLatitude(), data.getLongitude()))
         );
+
+        if (data.getArtRunSessionId() != null && artRunService.isParticipant(userId, data.getArtRunSessionId())) {
+            messagingTemplate.convertAndSend(
+                    "/topic/artrun/" + data.getArtRunSessionId(),
+                    WebSocketMessage.of("ARTRUN_LOCATION_UPDATE", ArtRunLocationRes.of(userId, data.getLatitude(), data.getLongitude()))
+            );
+        }
     }
 
     @MessageMapping("/ping")

--- a/src/main/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptor.java
@@ -1,5 +1,6 @@
 package com._s3k.runsync.global.websocket.interceptor;
 
+import com._s3k.runsync.domain.artrun.service.ArtRunService;
 import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.global.security.jwt.JwtValidator;
 import com._s3k.runsync.global.security.jwt.dto.JwtUserInfo;
@@ -17,9 +18,11 @@ import org.springframework.stereotype.Component;
 public class WebSocketAuthInterceptor implements ChannelInterceptor {
 
     private static final String FRIEND_TOPIC_PATTERN = "^/topic/(status|location)/\\d+$";
+    private static final String ARTRUN_TOPIC_PATTERN = "^/topic/artrun/\\d+$";
 
     private final JwtValidator jwtValidator;
     private final LocationService locationService;
+    private final ArtRunService artRunService;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -68,6 +71,25 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
 
                 if (!locationService.canSubscribeFriendTopic(Long.parseLong(subscriberUserId), Long.parseLong(targetUserId))) {
                     throw new IllegalArgumentException("친구가 아닌 사용자의 상태/위치를 구독할 수 없습니다.");
+                }
+            }
+
+            boolean isArtRunTopic = destination.equals("/topic/artrun") || destination.startsWith("/topic/artrun/");
+            boolean isValidArtRunTopic = destination.matches(ARTRUN_TOPIC_PATTERN);
+
+            if (isArtRunTopic && !isValidArtRunTopic) {
+                throw new IllegalArgumentException("잘못된 구독 경로입니다.");
+            }
+
+            if (isValidArtRunTopic) {
+                if (accessor.getUser() == null) {
+                    throw new IllegalArgumentException("인증되지 않은 사용자입니다.");
+                }
+
+                String sessionId = destination.substring(destination.lastIndexOf('/') + 1);
+                String subscriberUserId = accessor.getUser().getName();
+                if (!artRunService.isParticipant(Long.parseLong(subscriberUserId), Long.parseLong(sessionId))) {
+                    throw new IllegalArgumentException("세션 참가자가 아니면 구독할 수 없습니다.");
                 }
             }
         }

--- a/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
@@ -435,6 +435,26 @@ class ArtRunServiceTest {
                         .isEqualTo(ArtRunErrorCode.SESSION_NOT_FOUND));
     }
 
+    @Test
+    @DisplayName("참가자 여부 확인 - 참가중이면 true")
+    void isParticipant_true() {
+        // given
+        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(100L, 10L)).willReturn(true);
+
+        // when & then
+        assertThat(artRunService.isParticipant(10L, 100L)).isTrue();
+    }
+
+    @Test
+    @DisplayName("참가자 여부 확인 - 미참가면 false")
+    void isParticipant_false() {
+        // given
+        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(100L, 10L)).willReturn(false);
+
+        // when & then
+        assertThat(artRunService.isParticipant(10L, 100L)).isFalse();
+    }
+
     private ArtRunStatusUpdateReq statusReq(ArtRunStatus status) {
         ArtRunStatusUpdateReq request = new ArtRunStatusUpdateReq();
         ReflectionTestUtils.setField(request, "status", status);

--- a/src/test/java/com/_s3k/runsync/domain/location/handler/LocationMessageHandlerTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/location/handler/LocationMessageHandlerTest.java
@@ -1,0 +1,110 @@
+package com._s3k.runsync.domain.location.handler;
+
+import com._s3k.runsync.domain.artrun.service.ArtRunService;
+import com._s3k.runsync.domain.location.dto.request.LocationUpdateReq;
+import com._s3k.runsync.domain.location.service.LocationService;
+import com._s3k.runsync.domain.run.service.RunSessionService;
+import com._s3k.runsync.global.websocket.dto.WebSocketMessage;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.security.Principal;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+@ExtendWith(MockitoExtension.class)
+class LocationMessageHandlerTest {
+
+    @InjectMocks
+    private LocationMessageHandler handler;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Mock
+    private LocationService locationService;
+
+    @Mock
+    private RunSessionService runSessionService;
+
+    @Mock
+    private ArtRunService artRunService;
+
+    private final Principal principal = () -> "10";
+
+    @Test
+    @DisplayName("협동 러닝 참가자가 위치를 보내면 /topic/artrun/{id}로도 발행된다")
+    void handleLocation_artRunParticipant_publishesArtRunTopic() {
+        // given - artRunSessionId 100, 발행자(10)는 참가자
+        given(artRunService.isParticipant(10L, 100L)).willReturn(true);
+        WebSocketMessage<LocationUpdateReq> message = locationMessage(100L);
+
+        // when
+        handler.handleLocation(message, principal);
+
+        // then - 친구 토픽 + 협동러닝 토픽 둘 다 발행
+        verify(messagingTemplate).convertAndSend(eq("/topic/location/10"), any(Object.class));
+        verify(messagingTemplate).convertAndSend(eq("/topic/artrun/100"), any(Object.class));
+    }
+
+    @Test
+    @DisplayName("참가자가 아니면 /topic/artrun/{id}로 발행되지 않는다")
+    void handleLocation_notParticipant_doesNotPublishArtRunTopic() {
+        // given - artRunSessionId 100, 발행자(10)는 비참가자
+        given(artRunService.isParticipant(10L, 100L)).willReturn(false);
+        WebSocketMessage<LocationUpdateReq> message = locationMessage(100L);
+
+        // when
+        handler.handleLocation(message, principal);
+
+        // then - 친구 토픽은 발행, 협동러닝 토픽은 미발행
+        verify(messagingTemplate).convertAndSend(eq("/topic/location/10"), any(Object.class));
+        verify(messagingTemplate, never()).convertAndSend(eq("/topic/artrun/100"), any(Object.class));
+    }
+
+    @Test
+    @DisplayName("artRunSessionId가 없으면 참가자 검증/협동러닝 발행을 하지 않는다")
+    void handleLocation_noArtRunSessionId_doesNotPublishArtRunTopic() {
+        // given - artRunSessionId 없음
+        WebSocketMessage<LocationUpdateReq> message = locationMessage(null);
+
+        // when
+        handler.handleLocation(message, principal);
+
+        // then - 친구 토픽만 발행, 참가자 검증 호출 안 됨
+        verify(messagingTemplate).convertAndSend(eq("/topic/location/10"), any(Object.class));
+        verify(artRunService, never()).isParticipant(any(), any());
+    }
+
+    @Test
+    @DisplayName("인증 정보가 없으면 아무 동작도 하지 않는다")
+    void handleLocation_nullPrincipal_doesNothing() {
+        // given
+        WebSocketMessage<LocationUpdateReq> message = locationMessage(100L);
+
+        // when
+        handler.handleLocation(message, null);
+
+        // then
+        verifyNoInteractions(messagingTemplate, locationService, artRunService, runSessionService);
+    }
+
+    private WebSocketMessage<LocationUpdateReq> locationMessage(Long artRunSessionId) {
+        LocationUpdateReq data = new LocationUpdateReq();
+        ReflectionTestUtils.setField(data, "latitude", 37.5665);
+        ReflectionTestUtils.setField(data, "longitude", 126.9780);
+        ReflectionTestUtils.setField(data, "artRunSessionId", artRunSessionId);
+        return WebSocketMessage.of("LOCATION_UPDATE", data);
+    }
+}

--- a/src/test/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptorTest.java
+++ b/src/test/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptorTest.java
@@ -1,5 +1,6 @@
 package com._s3k.runsync.global.websocket.interceptor;
 
+import com._s3k.runsync.domain.artrun.service.ArtRunService;
 import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.global.security.jwt.JwtValidator;
 import com._s3k.runsync.global.security.jwt.dto.JwtUserInfo;
@@ -31,6 +32,9 @@ class WebSocketAuthInterceptorTest {
 
     @Mock
     private LocationService locationService;
+
+    @Mock
+    private ArtRunService artRunService;
 
     @Mock
     private MessageChannel channel;
@@ -106,6 +110,45 @@ class WebSocketAuthInterceptorTest {
         assertThatThrownBy(() -> interceptor.preSend(message, channel))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("인증되지 않은 사용자입니다.");
+    }
+
+    @Test
+    @DisplayName("협동 러닝 세션 topic 정상 구독 허용 - 참가자")
+    void subscribe_validArtRunTopic_allowed() {
+        // given
+        given(artRunService.isParticipant(1L, 100L)).willReturn(true);
+        Message<?> message = buildSubscribeMessage("/topic/artrun/100", "1");
+
+        // when
+        Message<?> result = interceptor.preSend(message, channel);
+
+        // then
+        assertThat(result).isNotNull();
+    }
+
+    @Test
+    @DisplayName("참가자가 아닌 사용자의 협동 러닝 세션 topic 구독 거부")
+    void subscribe_notParticipant_throwsException() {
+        // given
+        given(artRunService.isParticipant(1L, 100L)).willReturn(false);
+        Message<?> message = buildSubscribeMessage("/topic/artrun/100", "1");
+
+        // when & then
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("세션 참가자가 아니면 구독할 수 없습니다.");
+    }
+
+    @Test
+    @DisplayName("malformed 협동 러닝 topic 거부")
+    void subscribe_malformedArtRunTopic_throwsException() {
+        // given
+        Message<?> message = buildSubscribeMessage("/topic/artrun/abc", "1");
+
+        // when & then
+        assertThatThrownBy(() -> interceptor.preSend(message, channel))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("잘못된 구독 경로입니다.");
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> #39 

## 📝작업 내용

협동 러닝 실시간 위치 공유 WebSocket 확장했습니다.
- /topic/artrun/{sessionId} 구독 추가 — 참가자만 구독 가능 (친구 토픽이 "친구인지" 검증하듯, "같은 세션 참가자인지" 검증)
- LocationUpdateReq에 artRunSessionId 추가 → 보낼 때 그 세션 참가자면 /topic/artrun/{sessionId}로도 위치 발행
- 기존 친구 위치 공유(/topic/location/{userId}) 흐름은 그대로 유지

## 📷스크린샷 

<img width="1490" height="804" alt="스크린샷 2026-06-04 오후 1 12 14" src="https://github.com/user-attachments/assets/a256cdef-94c8-4624-81d8-16a293193591" />
