### PR TITLE
[Feat] 친구 요청 보내기 API 구현 (#34)

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
@@ -1,13 +1,18 @@
 package com._s3k.runsync.domain.friend.controller;
 
+import com._s3k.runsync.domain.friend.dto.request.FriendRequestReq;
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
+import com._s3k.runsync.domain.friend.dto.response.FriendRequestRes;
 import com._s3k.runsync.domain.friend.service.FriendService;
 import com._s3k.runsync.global.common.dto.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import java.util.List;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -17,6 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 public class FriendController {
 
     private final FriendService friendService;
+
+    @Operation(summary = "친구 요청 보내기", description = "특정 사용자에게 친구 요청 전송. 로그인 필요")
+    @PostMapping("/requests")
+    public CommonResponse<FriendRequestRes> createFriendRequest(
+            @AuthenticationPrincipal Long userId,
+            @Valid @RequestBody FriendRequestReq req) {
+        return CommonResponse.success(friendService.createFriendRequest(userId, req));
+    }
 
     @Operation(summary = "친구 목록 조회", description = "친구 목록 및 활동 상태 조회. 로그인 필요")
     @GetMapping

--- a/src/main/java/com/_s3k/runsync/domain/friend/dto/request/FriendRequestReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/dto/request/FriendRequestReq.java
@@ -1,0 +1,18 @@
+package com._s3k.runsync.domain.friend.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@Schema(description = "친구 요청 보내기 요청")
+public class FriendRequestReq {
+
+    @NotNull
+    @Schema(description = "친구 요청 받을 사용자 ID", example = "2")
+    private Long receiverId;
+}

--- a/src/main/java/com/_s3k/runsync/domain/friend/dto/request/FriendRequestReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/dto/request/FriendRequestReq.java
@@ -4,10 +4,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Getter
-@Setter
 @NoArgsConstructor
 @Schema(description = "친구 요청 보내기 요청")
 public class FriendRequestReq {
@@ -15,4 +13,10 @@ public class FriendRequestReq {
     @NotNull
     @Schema(description = "친구 요청 받을 사용자 ID", example = "2")
     private Long receiverId;
+
+    public static FriendRequestReq of(Long receiverId) {
+        FriendRequestReq req = new FriendRequestReq();
+        req.receiverId = receiverId;
+        return req;
+    }
 }

--- a/src/main/java/com/_s3k/runsync/domain/friend/dto/response/FriendRequestRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/dto/response/FriendRequestRes.java
@@ -1,0 +1,25 @@
+package com._s3k.runsync.domain.friend.dto.response;
+
+import com._s3k.runsync.entity.FriendRequest;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "친구 요청 보내기 응답")
+public class FriendRequestRes {
+
+    @Schema(description = "친구 요청 ID", example = "10")
+    private Long requestId;
+
+    @Schema(description = "요청 상태", example = "PENDING")
+    private String status;
+
+    private FriendRequestRes(Long requestId, String status) {
+        this.requestId = requestId;
+        this.status = status;
+    }
+
+    public static FriendRequestRes of(FriendRequest friendRequest) {
+        return new FriendRequestRes(friendRequest.getId(), friendRequest.getStatus().name());
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/friend/dto/response/FriendRequestRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/dto/response/FriendRequestRes.java
@@ -1,6 +1,7 @@
 package com._s3k.runsync.domain.friend.dto.response;
 
 import com._s3k.runsync.entity.FriendRequest;
+import com._s3k.runsync.entity.enums.FriendRequestStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
@@ -12,14 +13,14 @@ public class FriendRequestRes {
     private Long requestId;
 
     @Schema(description = "요청 상태", example = "PENDING")
-    private String status;
+    private FriendRequestStatus status;
 
-    private FriendRequestRes(Long requestId, String status) {
+    private FriendRequestRes(Long requestId, FriendRequestStatus status) {
         this.requestId = requestId;
         this.status = status;
     }
 
     public static FriendRequestRes of(FriendRequest friendRequest) {
-        return new FriendRequestRes(friendRequest.getId(), friendRequest.getStatus().name());
+        return new FriendRequestRes(friendRequest.getId(), friendRequest.getStatus());
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/friend/exception/FriendErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/exception/FriendErrorCode.java
@@ -11,9 +11,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum FriendErrorCode implements ResultCode {
 
-    FRIEND_SELF_REQUEST(HttpStatus.BAD_REQUEST, 3000, "자기 자신에게 친구 요청을 보낼 수 없습니다."),
-    FRIEND_REQUEST_ALREADY_SENT(HttpStatus.CONFLICT, 3001, "이미 친구 요청을 보냈습니다."),
-    FRIEND_ALREADY_EXISTS(HttpStatus.CONFLICT, 3002, "이미 친구 관계입니다.");
+    FRIEND_SELF_REQUEST(HttpStatus.BAD_REQUEST, 6000, "자기 자신에게 친구 요청을 보낼 수 없습니다."),
+    FRIEND_REQUEST_ALREADY_SENT(HttpStatus.CONFLICT, 6001, "이미 친구 요청을 보냈습니다."),
+    FRIEND_ALREADY_EXISTS(HttpStatus.CONFLICT, 6002, "이미 친구 관계입니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/domain/friend/exception/FriendErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/exception/FriendErrorCode.java
@@ -1,0 +1,21 @@
+package com._s3k.runsync.domain.friend.exception;
+
+import org.springframework.http.HttpStatus;
+
+import com._s3k.runsync.global.exception.ResultCode;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum FriendErrorCode implements ResultCode {
+
+    FRIEND_SELF_REQUEST(HttpStatus.BAD_REQUEST, 3000, "자기 자신에게 친구 요청을 보낼 수 없습니다."),
+    FRIEND_REQUEST_ALREADY_SENT(HttpStatus.CONFLICT, 3001, "이미 친구 요청을 보냈습니다."),
+    FRIEND_ALREADY_EXISTS(HttpStatus.CONFLICT, 3002, "이미 친구 관계입니다.");
+
+    private final HttpStatus status;
+    private final int code;
+    private final String message;
+}

--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
 
-    boolean existsBySenderIdAndReceiverIdAndStatus(Long senderId, Long receiverId, FriendRequestStatus status);
+    boolean existsBySender_IdAndReceiver_IdAndStatus(Long senderId, Long receiverId, FriendRequestStatus status);
 }

--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
@@ -1,0 +1,10 @@
+package com._s3k.runsync.domain.friend.repository;
+
+import com._s3k.runsync.entity.FriendRequest;
+import com._s3k.runsync.entity.enums.FriendRequestStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
+
+    boolean existsBySenderIdAndReceiverIdAndStatus(Long senderId, Long receiverId, FriendRequestStatus status);
+}

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -1,14 +1,23 @@
 package com._s3k.runsync.domain.friend.service;
 
+import com._s3k.runsync.domain.friend.dto.request.FriendRequestReq;
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
+import com._s3k.runsync.domain.friend.dto.response.FriendRequestRes;
+import com._s3k.runsync.domain.friend.exception.FriendErrorCode;
+import com._s3k.runsync.domain.friend.repository.FriendRequestRepository;
 import com._s3k.runsync.domain.friend.repository.FriendshipRepository;
 import com._s3k.runsync.domain.run.repository.RunRecordRepository;
 import com._s3k.runsync.domain.run.repository.RunningSessionRepository;
+import com._s3k.runsync.domain.users.exception.UserErrorCode;
+import com._s3k.runsync.domain.users.repository.UserRepository;
+import com._s3k.runsync.entity.FriendRequest;
 import com._s3k.runsync.entity.RunRecord;
 import com._s3k.runsync.entity.RunningSession;
 import com._s3k.runsync.entity.User;
 import com._s3k.runsync.entity.enums.ActivityStatus;
+import com._s3k.runsync.entity.enums.FriendRequestStatus;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
+import com._s3k.runsync.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,8 +35,38 @@ import java.util.stream.Collectors;
 public class FriendService {
 
     private final FriendshipRepository friendshipRepository;
+    private final FriendRequestRepository friendRequestRepository;
+    private final UserRepository userRepository;
     private final RunningSessionRepository runningSessionRepository;
     private final RunRecordRepository runRecordRepository;
+
+    @Transactional
+    public FriendRequestRes createFriendRequest(Long senderId, FriendRequestReq request) {
+        Long receiverId = request.getReceiverId();
+
+        if (senderId.equals(receiverId)) {
+            throw new GlobalException(FriendErrorCode.FRIEND_SELF_REQUEST);
+        }
+
+        User sender = userRepository.findById(senderId)
+                .filter(u -> !Boolean.TRUE.equals(u.getIsDeleted()))
+                .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
+
+        User receiver = userRepository.findById(receiverId)
+                .filter(u -> !Boolean.TRUE.equals(u.getIsDeleted()))
+                .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
+
+        if (friendRequestRepository.existsBySenderIdAndReceiverIdAndStatus(senderId, receiverId, FriendRequestStatus.PENDING)) {
+            throw new GlobalException(FriendErrorCode.FRIEND_REQUEST_ALREADY_SENT);
+        }
+
+        if (friendshipRepository.existsByUser_IdAndFriend_Id(senderId, receiverId)) {
+            throw new GlobalException(FriendErrorCode.FRIEND_ALREADY_EXISTS);
+        }
+
+        FriendRequest friendRequest = friendRequestRepository.save(FriendRequest.of(sender, receiver));
+        return FriendRequestRes.of(friendRequest);
+    }
 
     @Transactional(readOnly = true)
     public List<FriendListRes> getFriendsByUserId(Long userId) {

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -19,6 +19,7 @@ import com._s3k.runsync.entity.enums.FriendRequestStatus;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
 import com._s3k.runsync.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -56,7 +57,7 @@ public class FriendService {
                 .filter(u -> !Boolean.TRUE.equals(u.getIsDeleted()))
                 .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
 
-        if (friendRequestRepository.existsBySenderIdAndReceiverIdAndStatus(senderId, receiverId, FriendRequestStatus.PENDING)) {
+        if (friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(senderId, receiverId, FriendRequestStatus.PENDING)) {
             throw new GlobalException(FriendErrorCode.FRIEND_REQUEST_ALREADY_SENT);
         }
 
@@ -64,8 +65,12 @@ public class FriendService {
             throw new GlobalException(FriendErrorCode.FRIEND_ALREADY_EXISTS);
         }
 
-        FriendRequest friendRequest = friendRequestRepository.save(FriendRequest.of(sender, receiver));
-        return FriendRequestRes.of(friendRequest);
+        try {
+            FriendRequest friendRequest = friendRequestRepository.save(FriendRequest.of(sender, receiver));
+            return FriendRequestRes.of(friendRequest);
+        } catch (DataIntegrityViolationException e) {
+            throw new GlobalException(FriendErrorCode.FRIEND_REQUEST_ALREADY_SENT);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/_s3k/runsync/entity/FriendRequest.java
+++ b/src/main/java/com/_s3k/runsync/entity/FriendRequest.java
@@ -8,7 +8,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "friend_requests")
+@Table(name = "friend_requests",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"sender_id", "receiver_id", "status"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FriendRequest extends BaseEntity {

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -1,14 +1,23 @@
 package com._s3k.runsync.domain.friend.service;
 
+import com._s3k.runsync.domain.friend.dto.request.FriendRequestReq;
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
+import com._s3k.runsync.domain.friend.dto.response.FriendRequestRes;
+import com._s3k.runsync.domain.friend.exception.FriendErrorCode;
+import com._s3k.runsync.domain.friend.repository.FriendRequestRepository;
 import com._s3k.runsync.domain.friend.repository.FriendshipRepository;
 import com._s3k.runsync.domain.run.repository.RunRecordRepository;
 import com._s3k.runsync.domain.run.repository.RunningSessionRepository;
+import com._s3k.runsync.domain.users.exception.UserErrorCode;
+import com._s3k.runsync.domain.users.repository.UserRepository;
+import com._s3k.runsync.entity.FriendRequest;
 import com._s3k.runsync.entity.RunRecord;
 import com._s3k.runsync.entity.RunningSession;
 import com._s3k.runsync.entity.User;
 import com._s3k.runsync.entity.enums.ActivityStatus;
+import com._s3k.runsync.entity.enums.FriendRequestStatus;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
+import com._s3k.runsync.global.exception.GlobalException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,8 +27,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
@@ -35,10 +47,136 @@ class FriendServiceTest {
     private FriendshipRepository friendshipRepository;
 
     @Mock
+    private FriendRequestRepository friendRequestRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
     private RunningSessionRepository runningSessionRepository;
 
     @Mock
     private RunRecordRepository runRecordRepository;
+
+    @Test
+    @DisplayName("친구 요청 정상 전송")
+    void createFriendRequest_success() {
+        // given
+        FriendRequestReq req = new FriendRequestReq();
+        req.setReceiverId(2L);
+
+        User sender = mock(User.class);
+        User receiver = mock(User.class);
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(1L, 2L, FriendRequestStatus.PENDING)).willReturn(false);
+        given(friendshipRepository.existsByUser_IdAndFriend_Id(1L, 2L)).willReturn(false);
+
+        FriendRequest savedRequest = mock(FriendRequest.class);
+        given(savedRequest.getId()).willReturn(1L);
+        given(savedRequest.getStatus()).willReturn(FriendRequestStatus.PENDING);
+        given(friendRequestRepository.save(any())).willReturn(savedRequest);
+
+        // when
+        FriendRequestRes result = friendService.createFriendRequest(1L, req);
+
+        // then
+        assertThat(result.getRequestId()).isEqualTo(1L);
+        assertThat(result.getStatus()).isEqualTo(FriendRequestStatus.PENDING.name());
+    }
+
+    @Test
+    @DisplayName("자기 자신에게 친구 요청 시 FRIEND_SELF_REQUEST 예외 발생")
+    void createFriendRequest_selfRequest() {
+        // given
+        FriendRequestReq req = new FriendRequestReq();
+        req.setReceiverId(1L);
+
+        // when & then
+        assertThatThrownBy(() -> friendService.createFriendRequest(1L, req))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(FriendErrorCode.FRIEND_SELF_REQUEST));
+    }
+
+    @Test
+    @DisplayName("존재하지 않거나 탈퇴한 수신자에게 요청 시 USER_NOT_FOUND 예외 발생")
+    void createFriendRequest_receiverNotFound() {
+        // given
+        FriendRequestReq req = new FriendRequestReq();
+        req.setReceiverId(2L);
+
+        User sender = mock(User.class);
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> friendService.createFriendRequest(1L, req))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("탈퇴한 수신자에게 요청 시 USER_NOT_FOUND 예외 발생")
+    void createFriendRequest_receiverDeleted() {
+        // given
+        FriendRequestReq req = new FriendRequestReq();
+        req.setReceiverId(2L);
+
+        User sender = mock(User.class);
+        User deletedReceiver = mock(User.class);
+        given(deletedReceiver.getIsDeleted()).willReturn(true);
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.of(deletedReceiver));
+
+        // when & then
+        assertThatThrownBy(() -> friendService.createFriendRequest(1L, req))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(UserErrorCode.USER_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("이미 PENDING 요청이 있으면 FRIEND_REQUEST_ALREADY_SENT 예외 발생")
+    void createFriendRequest_alreadySent() {
+        // given
+        FriendRequestReq req = new FriendRequestReq();
+        req.setReceiverId(2L);
+
+        User sender = mock(User.class);
+        User receiver = mock(User.class);
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(1L, 2L, FriendRequestStatus.PENDING)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> friendService.createFriendRequest(1L, req))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(FriendErrorCode.FRIEND_REQUEST_ALREADY_SENT));
+    }
+
+    @Test
+    @DisplayName("이미 친구 관계이면 FRIEND_ALREADY_EXISTS 예외 발생")
+    void createFriendRequest_alreadyFriends() {
+        // given
+        FriendRequestReq req = new FriendRequestReq();
+        req.setReceiverId(2L);
+
+        User sender = mock(User.class);
+        User receiver = mock(User.class);
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(1L, 2L, FriendRequestStatus.PENDING)).willReturn(false);
+        given(friendshipRepository.existsByUser_IdAndFriend_Id(1L, 2L)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> friendService.createFriendRequest(1L, req))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(FriendErrorCode.FRIEND_ALREADY_EXISTS));
+    }
 
     @Test
     @DisplayName("친구가 없으면 빈 리스트 반환")

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -62,8 +62,7 @@ class FriendServiceTest {
     @DisplayName("친구 요청 정상 전송")
     void createFriendRequest_success() {
         // given
-        FriendRequestReq req = new FriendRequestReq();
-        req.setReceiverId(2L);
+        FriendRequestReq req = FriendRequestReq.of(2L);
 
         User sender = mock(User.class);
         User receiver = mock(User.class);
@@ -82,15 +81,14 @@ class FriendServiceTest {
 
         // then
         assertThat(result.getRequestId()).isEqualTo(1L);
-        assertThat(result.getStatus()).isEqualTo(FriendRequestStatus.PENDING.name());
+        assertThat(result.getStatus()).isEqualTo(FriendRequestStatus.PENDING);
     }
 
     @Test
     @DisplayName("자기 자신에게 친구 요청 시 FRIEND_SELF_REQUEST 예외 발생")
     void createFriendRequest_selfRequest() {
         // given
-        FriendRequestReq req = new FriendRequestReq();
-        req.setReceiverId(1L);
+        FriendRequestReq req = FriendRequestReq.of(1L);
 
         // when & then
         assertThatThrownBy(() -> friendService.createFriendRequest(1L, req))
@@ -103,8 +101,7 @@ class FriendServiceTest {
     @DisplayName("존재하지 않거나 탈퇴한 수신자에게 요청 시 USER_NOT_FOUND 예외 발생")
     void createFriendRequest_receiverNotFound() {
         // given
-        FriendRequestReq req = new FriendRequestReq();
-        req.setReceiverId(2L);
+        FriendRequestReq req = FriendRequestReq.of(2L);
 
         User sender = mock(User.class);
         given(userRepository.findById(1L)).willReturn(Optional.of(sender));
@@ -121,8 +118,7 @@ class FriendServiceTest {
     @DisplayName("탈퇴한 수신자에게 요청 시 USER_NOT_FOUND 예외 발생")
     void createFriendRequest_receiverDeleted() {
         // given
-        FriendRequestReq req = new FriendRequestReq();
-        req.setReceiverId(2L);
+        FriendRequestReq req = FriendRequestReq.of(2L);
 
         User sender = mock(User.class);
         User deletedReceiver = mock(User.class);
@@ -141,8 +137,7 @@ class FriendServiceTest {
     @DisplayName("이미 PENDING 요청이 있으면 FRIEND_REQUEST_ALREADY_SENT 예외 발생")
     void createFriendRequest_alreadySent() {
         // given
-        FriendRequestReq req = new FriendRequestReq();
-        req.setReceiverId(2L);
+        FriendRequestReq req = FriendRequestReq.of(2L);
 
         User sender = mock(User.class);
         User receiver = mock(User.class);
@@ -161,8 +156,7 @@ class FriendServiceTest {
     @DisplayName("이미 친구 관계이면 FRIEND_ALREADY_EXISTS 예외 발생")
     void createFriendRequest_alreadyFriends() {
         // given
-        FriendRequestReq req = new FriendRequestReq();
-        req.setReceiverId(2L);
+        FriendRequestReq req = FriendRequestReq.of(2L);
 
         User sender = mock(User.class);
         User receiver = mock(User.class);


### PR DESCRIPTION
## Related Issue
  - Close #34

## Task
  - POST /api/friends/requests 엔드포인트 구현
  - FriendRequestReq, FriendRequestRes DTO 생성
  - FriendErrorCode 추가 (자기 자신 요청, 중복 요청, 이미 친구)
  - FriendRequestRepository 생성 (PENDING 상태 중복 요청 확인)
  - FriendService.createFriendRequest() 구현
    - 자기 자신 요청 검증
    - 수신자 존재 및 탈퇴 여부 검증
    - PENDING 상태 중복 요청 검증
    - 이미 친구 관계 검증
    - FriendRequest 저장 후 응답 반환

## To Reviewer
  - 친구 관계 존재 확인 시 existsByUser_IdAndFriend_Id() 사용 — 수락 API에서
  양방향(A→B, B→A) 저장을 보장하는 전제로 단방향 조회로 처리
  - 다단계 검증 순서: DB 조회 없는 검증(자기 자신) → 유저 존재 확인 → 중복 요청 →
  이미 친구 순으로 early return

## Reference
  - 없음

## Check List
  - [ ] PR 제목 규칙 준수
  - [ ] 라벨과 리뷰어 설정
  - [ ] 민감파일(*.yml 등) .gitignore 설정 

<img width="739" height="886" alt="image" src="https://github.com/user-attachments/assets/a5e6a766-923a-4be5-9811-8b24312537aa" />
