### PR TITLE
[Feat] 협동 러닝 위치 구독 권한 회수 및 세션 속성 캐싱

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/artrun/event/ArtRunParticipantLeftEvent.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/event/ArtRunParticipantLeftEvent.java
@@ -1,0 +1,4 @@
+package com._s3k.runsync.domain.artrun.event;
+
+public record ArtRunParticipantLeftEvent(Long sessionId, Long userId) {
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/event/ArtRunSessionClosedEvent.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/event/ArtRunSessionClosedEvent.java
@@ -1,0 +1,4 @@
+package com._s3k.runsync.domain.artrun.event;
+
+public record ArtRunSessionClosedEvent(Long sessionId) {
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/handler/ArtRunEventListener.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/handler/ArtRunEventListener.java
@@ -1,0 +1,32 @@
+package com._s3k.runsync.domain.artrun.handler;
+
+import com._s3k.runsync.domain.artrun.event.ArtRunParticipantLeftEvent;
+import com._s3k.runsync.domain.artrun.event.ArtRunSessionClosedEvent;
+import com._s3k.runsync.global.websocket.dto.WebSocketMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class ArtRunEventListener {
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    @TransactionalEventListener
+    public void onSessionClosed(ArtRunSessionClosedEvent event) {
+        messagingTemplate.convertAndSend(
+                "/topic/artrun/" + event.sessionId(),
+                WebSocketMessage.of("ARTRUN_SESSION_CLOSED", event.sessionId())
+        );
+    }
+
+    @TransactionalEventListener
+    public void onParticipantLeft(ArtRunParticipantLeftEvent event) {
+        messagingTemplate.convertAndSend(
+                "/topic/artrun/" + event.sessionId(),
+                WebSocketMessage.of("ARTRUN_PARTICIPANT_LEFT", event.userId())
+        );
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
@@ -10,6 +10,8 @@ import com._s3k.runsync.domain.artrun.dto.response.ArtRunRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunScrollRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunStatusRes;
 import com._s3k.runsync.domain.artrun.dto.response.ParticipantRes;
+import com._s3k.runsync.domain.artrun.event.ArtRunParticipantLeftEvent;
+import com._s3k.runsync.domain.artrun.event.ArtRunSessionClosedEvent;
 import com._s3k.runsync.domain.artrun.exception.ArtRunErrorCode;
 import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
 import com._s3k.runsync.domain.artrun.repository.ArtRunSessionRepository;
@@ -28,6 +30,7 @@ import org.locationtech.jts.geom.GeometryFactory;
 import org.locationtech.jts.geom.LineString;
 import org.locationtech.jts.geom.Point;
 import org.locationtech.jts.geom.PrecisionModel;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -45,6 +48,7 @@ public class ArtRunService {
     private final UserRepository userRepository;
     private final ArtRunSessionRepository artRunSessionRepository;
     private final ArtRunParticipantRepository artRunParticipantRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
     public ArtRunCreateRes createArtRun(Long userId, ArtRunCreateReq request) {
@@ -115,7 +119,7 @@ public class ArtRunService {
 
     @Transactional
     public void leaveArtRun(Long userId, Long sessionId) {
-        ArtRunSession session = artRunSessionRepository.findByIdWithHost(sessionId)
+        ArtRunSession session = artRunSessionRepository.findByIdWithLock(sessionId)
                 .orElseThrow(() -> new GlobalException(ArtRunErrorCode.SESSION_NOT_FOUND));
 
         if (!session.isRecruiting()) {
@@ -128,6 +132,8 @@ public class ArtRunService {
         ArtRunParticipant participant = artRunParticipantRepository.findByArtRunSession_IdAndUser_Id(sessionId, userId)
                 .orElseThrow(() -> new GlobalException(ArtRunErrorCode.NOT_PARTICIPANT));
         artRunParticipantRepository.delete(participant);
+
+        eventPublisher.publishEvent(new ArtRunParticipantLeftEvent(sessionId, userId));
     }
 
     @Transactional
@@ -157,11 +163,8 @@ public class ArtRunService {
 
         artRunParticipantRepository.deleteByArtRunSession_Id(sessionId);
         artRunSessionRepository.delete(session);
-    }
 
-    @Transactional(readOnly = true)
-    public boolean isParticipant(Long userId, Long sessionId) {
-        return artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(sessionId, userId);
+        eventPublisher.publishEvent(new ArtRunSessionClosedEvent(sessionId));
     }
 
     private Map<Long, Long> countParticipantsBySession(List<ArtRunSession> sessions) {

--- a/src/main/java/com/_s3k/runsync/domain/location/handler/LocationMessageHandler.java
+++ b/src/main/java/com/_s3k/runsync/domain/location/handler/LocationMessageHandler.java
@@ -1,21 +1,23 @@
 package com._s3k.runsync.domain.location.handler;
 
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunLocationRes;
-import com._s3k.runsync.domain.artrun.service.ArtRunService;
 import com._s3k.runsync.domain.run.service.RunSessionService;
 import com._s3k.runsync.global.exception.GlobalException;
 import com._s3k.runsync.global.websocket.dto.WebSocketMessage;
+import com._s3k.runsync.global.websocket.interceptor.WebSocketAuthInterceptor;
 import com._s3k.runsync.domain.location.dto.request.LocationUpdateReq;
 import com._s3k.runsync.domain.location.dto.response.FriendLocationRes;
 import com._s3k.runsync.domain.location.service.LocationService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.handler.annotation.MessageExceptionHandler;
 import org.springframework.messaging.handler.annotation.MessageMapping;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.messaging.simp.annotation.SendToUser;
 import org.springframework.stereotype.Controller;
 
 import java.security.Principal;
+import java.util.Map;
 
 @Controller
 @RequiredArgsConstructor
@@ -24,10 +26,10 @@ public class LocationMessageHandler {
     private final SimpMessagingTemplate messagingTemplate;
     private final LocationService locationService;
     private final RunSessionService runSessionService;
-    private final ArtRunService artRunService;
 
     @MessageMapping("/location")
-    public void handleLocation(WebSocketMessage<LocationUpdateReq> message, Principal principal) {
+    public void handleLocation(WebSocketMessage<LocationUpdateReq> message, Principal principal,
+                               SimpMessageHeaderAccessor headerAccessor) {
         if (principal == null) return;
         Long userId = Long.parseLong(principal.getName());
         LocationUpdateReq data = message.getData();
@@ -47,12 +49,20 @@ public class LocationMessageHandler {
                 WebSocketMessage.of("FRIEND_LOCATION_UPDATE", FriendLocationRes.of(userId, data.getLatitude(), data.getLongitude()))
         );
 
-        if (data.getArtRunSessionId() != null && artRunService.isParticipant(userId, data.getArtRunSessionId())) {
+        if (data.getArtRunSessionId() != null && isSubscribedToArtRun(headerAccessor, data.getArtRunSessionId())) {
             messagingTemplate.convertAndSend(
                     "/topic/artrun/" + data.getArtRunSessionId(),
                     WebSocketMessage.of("ARTRUN_LOCATION_UPDATE", ArtRunLocationRes.of(userId, data.getLatitude(), data.getLongitude()))
             );
         }
+    }
+
+    private boolean isSubscribedToArtRun(SimpMessageHeaderAccessor headerAccessor, Long artRunSessionId) {
+        if (headerAccessor.getSessionAttributes() == null) {
+            return false;
+        }
+        Object subscriptions = headerAccessor.getSessionAttributes().get(WebSocketAuthInterceptor.ARTRUN_SUBSCRIPTIONS);
+        return subscriptions instanceof Map<?, ?> map && map.containsValue(artRunSessionId);
     }
 
     @MessageMapping("/ping")

--- a/src/main/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptor.java
@@ -1,6 +1,6 @@
 package com._s3k.runsync.global.websocket.interceptor;
 
-import com._s3k.runsync.domain.artrun.service.ArtRunService;
+import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
 import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.global.security.jwt.JwtValidator;
 import com._s3k.runsync.global.security.jwt.dto.JwtUserInfo;
@@ -13,16 +13,21 @@ import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.MessageHeaderAccessor;
 import org.springframework.stereotype.Component;
 
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
 @Component
 @RequiredArgsConstructor
 public class WebSocketAuthInterceptor implements ChannelInterceptor {
+
+    public static final String ARTRUN_SUBSCRIPTIONS = "artRunSubscriptions";
 
     private static final String FRIEND_TOPIC_PATTERN = "^/topic/(status|location)/\\d+$";
     private static final String ARTRUN_TOPIC_PATTERN = "^/topic/artrun/\\d+$";
 
     private final JwtValidator jwtValidator;
     private final LocationService locationService;
-    private final ArtRunService artRunService;
+    private final ArtRunParticipantRepository artRunParticipantRepository;
 
     @Override
     public Message<?> preSend(Message<?> message, MessageChannel channel) {
@@ -86,14 +91,31 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
                     throw new IllegalArgumentException("인증되지 않은 사용자입니다.");
                 }
 
-                String sessionId = destination.substring(destination.lastIndexOf('/') + 1);
-                String subscriberUserId = accessor.getUser().getName();
-                if (!artRunService.isParticipant(Long.parseLong(subscriberUserId), Long.parseLong(sessionId))) {
+                Long sessionId = Long.parseLong(destination.substring(destination.lastIndexOf('/') + 1));
+                Long subscriberUserId = Long.parseLong(accessor.getUser().getName());
+                if (!artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(sessionId, subscriberUserId)) {
                     throw new IllegalArgumentException("세션 참가자가 아니면 구독할 수 없습니다.");
                 }
+
+                // 구독 시 검증한 참가 정보를 세션에 캐싱 → 발행 시 DB 재조회 없이 활용
+                artRunSubscriptions(accessor).put(accessor.getSubscriptionId(), sessionId);
             }
         }
 
+        if (StompCommand.UNSUBSCRIBE.equals(accessor.getCommand())) {
+            artRunSubscriptions(accessor).remove(accessor.getSubscriptionId());
+        }
+
         return message;
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<String, Long> artRunSubscriptions(StompHeaderAccessor accessor) {
+        Map<String, Object> attributes = accessor.getSessionAttributes();
+        if (attributes == null) {
+            attributes = new ConcurrentHashMap<>();
+            accessor.setSessionAttributes(attributes);
+        }
+        return (Map<String, Long>) attributes.computeIfAbsent(ARTRUN_SUBSCRIPTIONS, k -> new ConcurrentHashMap<String, Long>());
     }
 }

--- a/src/test/java/com/_s3k/runsync/domain/artrun/handler/ArtRunEventListenerTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/artrun/handler/ArtRunEventListenerTest.java
@@ -1,0 +1,41 @@
+package com._s3k.runsync.domain.artrun.handler;
+
+import com._s3k.runsync.domain.artrun.event.ArtRunParticipantLeftEvent;
+import com._s3k.runsync.domain.artrun.event.ArtRunSessionClosedEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class ArtRunEventListenerTest {
+
+    @InjectMocks
+    private ArtRunEventListener listener;
+
+    @Mock
+    private SimpMessagingTemplate messagingTemplate;
+
+    @Test
+    @DisplayName("세션 종료 이벤트 → /topic/artrun/{id}로 발행")
+    void onSessionClosed_broadcasts() {
+        listener.onSessionClosed(new ArtRunSessionClosedEvent(8L));
+
+        verify(messagingTemplate).convertAndSend(eq("/topic/artrun/8"), any(Object.class));
+    }
+
+    @Test
+    @DisplayName("참가자 이탈 이벤트 → /topic/artrun/{id}로 발행")
+    void onParticipantLeft_broadcasts() {
+        listener.onParticipantLeft(new ArtRunParticipantLeftEvent(8L, 10L));
+
+        verify(messagingTemplate).convertAndSend(eq("/topic/artrun/8"), any(Object.class));
+    }
+}

--- a/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
@@ -7,6 +7,8 @@ import com._s3k.runsync.domain.artrun.dto.request.MeetingPlaceReq;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunDetailRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunScrollRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunStatusRes;
+import com._s3k.runsync.domain.artrun.event.ArtRunParticipantLeftEvent;
+import com._s3k.runsync.domain.artrun.event.ArtRunSessionClosedEvent;
 import com._s3k.runsync.domain.artrun.exception.ArtRunErrorCode;
 import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
 import com._s3k.runsync.domain.artrun.repository.ArtRunSessionRepository;
@@ -31,6 +33,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -62,6 +65,9 @@ class ArtRunServiceTest {
 
     @Mock
     private ArtRunParticipantRepository artRunParticipantRepository;
+
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
 
     @Test
     @DisplayName("협동 러닝 세션 생성 성공 - RECRUITING 상태로 저장되고 좌표가 경도/위도 순으로 저장된다")
@@ -263,7 +269,7 @@ class ArtRunServiceTest {
         // given - host id=1, 취소 요청자는 10L
         ArtRunSession session = session(1L, "강아지런");
         ArtRunParticipant participant = participant(10L, "현우", session);
-        given(artRunSessionRepository.findByIdWithHost(1L)).willReturn(Optional.of(session));
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.of(session));
         given(artRunParticipantRepository.findByArtRunSession_IdAndUser_Id(1L, 10L)).willReturn(Optional.of(participant));
 
         // when
@@ -271,6 +277,7 @@ class ArtRunServiceTest {
 
         // then
         verify(artRunParticipantRepository).delete(participant);
+        verify(eventPublisher).publishEvent(new ArtRunParticipantLeftEvent(1L, 10L));
     }
 
     @Test
@@ -278,7 +285,7 @@ class ArtRunServiceTest {
     void leaveArtRun_hostCannotLeave() {
         // given - host id=1, 취소 요청자도 1L
         ArtRunSession session = session(1L, "강아지런");
-        given(artRunSessionRepository.findByIdWithHost(1L)).willReturn(Optional.of(session));
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.of(session));
 
         // when & then
         assertThatThrownBy(() -> artRunService.leaveArtRun(1L, 1L))
@@ -293,7 +300,7 @@ class ArtRunServiceTest {
     void leaveArtRun_notParticipant() {
         // given - host id=1, 요청자 10L은 미참가
         ArtRunSession session = session(1L, "강아지런");
-        given(artRunSessionRepository.findByIdWithHost(1L)).willReturn(Optional.of(session));
+        given(artRunSessionRepository.findByIdWithLock(1L)).willReturn(Optional.of(session));
         given(artRunParticipantRepository.findByArtRunSession_IdAndUser_Id(1L, 10L)).willReturn(Optional.empty());
 
         // when & then
@@ -388,6 +395,7 @@ class ArtRunServiceTest {
         // then
         verify(artRunParticipantRepository).deleteByArtRunSession_Id(1L);
         verify(artRunSessionRepository).delete(session);
+        verify(eventPublisher).publishEvent(new ArtRunSessionClosedEvent(1L));
     }
 
     @Test
@@ -433,26 +441,6 @@ class ArtRunServiceTest {
                 .isInstanceOf(GlobalException.class)
                 .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
                         .isEqualTo(ArtRunErrorCode.SESSION_NOT_FOUND));
-    }
-
-    @Test
-    @DisplayName("참가자 여부 확인 - 참가중이면 true")
-    void isParticipant_true() {
-        // given
-        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(100L, 10L)).willReturn(true);
-
-        // when & then
-        assertThat(artRunService.isParticipant(10L, 100L)).isTrue();
-    }
-
-    @Test
-    @DisplayName("참가자 여부 확인 - 미참가면 false")
-    void isParticipant_false() {
-        // given
-        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(100L, 10L)).willReturn(false);
-
-        // when & then
-        assertThat(artRunService.isParticipant(10L, 100L)).isFalse();
     }
 
     private ArtRunStatusUpdateReq statusReq(ArtRunStatus status) {

--- a/src/test/java/com/_s3k/runsync/domain/location/handler/LocationMessageHandlerTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/location/handler/LocationMessageHandlerTest.java
@@ -1,24 +1,27 @@
 package com._s3k.runsync.domain.location.handler;
 
-import com._s3k.runsync.domain.artrun.service.ArtRunService;
 import com._s3k.runsync.domain.location.dto.request.LocationUpdateReq;
 import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.domain.run.service.RunSessionService;
 import com._s3k.runsync.global.websocket.dto.WebSocketMessage;
+import com._s3k.runsync.global.websocket.interceptor.WebSocketAuthInterceptor;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.messaging.simp.SimpMessageHeaderAccessor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.security.Principal;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -38,53 +41,48 @@ class LocationMessageHandlerTest {
     @Mock
     private RunSessionService runSessionService;
 
-    @Mock
-    private ArtRunService artRunService;
-
     private final Principal principal = () -> "10";
 
     @Test
-    @DisplayName("협동 러닝 참가자가 위치를 보내면 /topic/artrun/{id}로도 발행된다")
-    void handleLocation_artRunParticipant_publishesArtRunTopic() {
-        // given - artRunSessionId 100, 발행자(10)는 참가자
-        given(artRunService.isParticipant(10L, 100L)).willReturn(true);
+    @DisplayName("협동 러닝 토픽 구독자가 위치를 보내면 /topic/artrun/{id}로도 발행된다")
+    void handleLocation_subscribedToArtRun_publishesArtRunTopic() {
+        // given - 세션 속성에 sessionId 100 구독 기록 있음
         WebSocketMessage<LocationUpdateReq> message = locationMessage(100L);
 
         // when
-        handler.handleLocation(message, principal);
+        handler.handleLocation(message, principal, headerAccessor(100L));
 
-        // then - 친구 토픽 + 협동러닝 토픽 둘 다 발행
+        // then
         verify(messagingTemplate).convertAndSend(eq("/topic/location/10"), any(Object.class));
         verify(messagingTemplate).convertAndSend(eq("/topic/artrun/100"), any(Object.class));
     }
 
     @Test
-    @DisplayName("참가자가 아니면 /topic/artrun/{id}로 발행되지 않는다")
-    void handleLocation_notParticipant_doesNotPublishArtRunTopic() {
-        // given - artRunSessionId 100, 발행자(10)는 비참가자
-        given(artRunService.isParticipant(10L, 100L)).willReturn(false);
+    @DisplayName("협동 러닝 토픽 구독 기록이 없으면 /topic/artrun/{id}로 발행되지 않는다")
+    void handleLocation_notSubscribed_doesNotPublishArtRunTopic() {
+        // given - 세션 속성에 구독 기록 없음
         WebSocketMessage<LocationUpdateReq> message = locationMessage(100L);
 
         // when
-        handler.handleLocation(message, principal);
+        handler.handleLocation(message, principal, headerAccessor(null));
 
-        // then - 친구 토픽은 발행, 협동러닝 토픽은 미발행
+        // then
         verify(messagingTemplate).convertAndSend(eq("/topic/location/10"), any(Object.class));
         verify(messagingTemplate, never()).convertAndSend(eq("/topic/artrun/100"), any(Object.class));
     }
 
     @Test
-    @DisplayName("artRunSessionId가 없으면 참가자 검증/협동러닝 발행을 하지 않는다")
+    @DisplayName("artRunSessionId가 없으면 협동러닝 토픽으로 발행하지 않는다")
     void handleLocation_noArtRunSessionId_doesNotPublishArtRunTopic() {
-        // given - artRunSessionId 없음
+        // given - artRunSessionId 없음 (구독 기록은 있어도 무관)
         WebSocketMessage<LocationUpdateReq> message = locationMessage(null);
 
         // when
-        handler.handleLocation(message, principal);
+        handler.handleLocation(message, principal, headerAccessor(100L));
 
-        // then - 친구 토픽만 발행, 참가자 검증 호출 안 됨
+        // then
         verify(messagingTemplate).convertAndSend(eq("/topic/location/10"), any(Object.class));
-        verify(artRunService, never()).isParticipant(any(), any());
+        verify(messagingTemplate, never()).convertAndSend(eq("/topic/artrun/100"), any(Object.class));
     }
 
     @Test
@@ -94,10 +92,10 @@ class LocationMessageHandlerTest {
         WebSocketMessage<LocationUpdateReq> message = locationMessage(100L);
 
         // when
-        handler.handleLocation(message, null);
+        handler.handleLocation(message, null, headerAccessor(100L));
 
         // then
-        verifyNoInteractions(messagingTemplate, locationService, artRunService, runSessionService);
+        verifyNoInteractions(messagingTemplate, locationService, runSessionService);
     }
 
     private WebSocketMessage<LocationUpdateReq> locationMessage(Long artRunSessionId) {
@@ -106,5 +104,17 @@ class LocationMessageHandlerTest {
         ReflectionTestUtils.setField(data, "longitude", 126.9780);
         ReflectionTestUtils.setField(data, "artRunSessionId", artRunSessionId);
         return WebSocketMessage.of("LOCATION_UPDATE", data);
+    }
+
+    private SimpMessageHeaderAccessor headerAccessor(Long subscribedSessionId) {
+        SimpMessageHeaderAccessor accessor = SimpMessageHeaderAccessor.create();
+        Map<String, Object> attributes = new HashMap<>();
+        if (subscribedSessionId != null) {
+            Map<String, Long> subscriptions = new ConcurrentHashMap<>();
+            subscriptions.put("sub-0", subscribedSessionId);
+            attributes.put(WebSocketAuthInterceptor.ARTRUN_SUBSCRIPTIONS, subscriptions);
+        }
+        accessor.setSessionAttributes(attributes);
+        return accessor;
     }
 }

--- a/src/test/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptorTest.java
+++ b/src/test/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptorTest.java
@@ -1,6 +1,6 @@
 package com._s3k.runsync.global.websocket.interceptor;
 
-import com._s3k.runsync.domain.artrun.service.ArtRunService;
+import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
 import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.global.security.jwt.JwtValidator;
 import com._s3k.runsync.global.security.jwt.dto.JwtUserInfo;
@@ -15,6 +15,10 @@ import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.simp.stomp.StompCommand;
 import org.springframework.messaging.simp.stomp.StompHeaderAccessor;
 import org.springframework.messaging.support.MessageBuilder;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
@@ -34,7 +38,7 @@ class WebSocketAuthInterceptorTest {
     private LocationService locationService;
 
     @Mock
-    private ArtRunService artRunService;
+    private ArtRunParticipantRepository artRunParticipantRepository;
 
     @Mock
     private MessageChannel channel;
@@ -45,6 +49,21 @@ class WebSocketAuthInterceptorTest {
         if (principalName != null) {
             accessor.setUser(() -> principalName);
         }
+        accessor.setSubscriptionId("sub-0");
+        accessor.setSessionAttributes(new HashMap<>());
+        accessor.setSessionId("test-session");
+        return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+    }
+
+    private Message<?> buildArtRunSubscribe(String destination, String principalName, String subscriptionId,
+                                            Map<String, Object> sessionAttributes) {
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.SUBSCRIBE);
+        accessor.setDestination(destination);
+        if (principalName != null) {
+            accessor.setUser(() -> principalName);
+        }
+        accessor.setSubscriptionId(subscriptionId);
+        accessor.setSessionAttributes(sessionAttributes);
         accessor.setSessionId("test-session");
         return MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
     }
@@ -116,7 +135,7 @@ class WebSocketAuthInterceptorTest {
     @DisplayName("협동 러닝 세션 topic 정상 구독 허용 - 참가자")
     void subscribe_validArtRunTopic_allowed() {
         // given
-        given(artRunService.isParticipant(1L, 100L)).willReturn(true);
+        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(100L, 1L)).willReturn(true);
         Message<?> message = buildSubscribeMessage("/topic/artrun/100", "1");
 
         // when
@@ -130,7 +149,7 @@ class WebSocketAuthInterceptorTest {
     @DisplayName("참가자가 아닌 사용자의 협동 러닝 세션 topic 구독 거부")
     void subscribe_notParticipant_throwsException() {
         // given
-        given(artRunService.isParticipant(1L, 100L)).willReturn(false);
+        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(100L, 1L)).willReturn(false);
         Message<?> message = buildSubscribeMessage("/topic/artrun/100", "1");
 
         // when & then
@@ -149,6 +168,45 @@ class WebSocketAuthInterceptorTest {
         assertThatThrownBy(() -> interceptor.preSend(message, channel))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("잘못된 구독 경로입니다.");
+    }
+
+    @Test
+    @DisplayName("협동 러닝 세션 구독 시 sessionId가 세션 속성에 캐싱된다")
+    void subscribe_validArtRunTopic_cachesSubscription() {
+        // given
+        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(100L, 1L)).willReturn(true);
+        Map<String, Object> attributes = new HashMap<>();
+        Message<?> message = buildArtRunSubscribe("/topic/artrun/100", "1", "sub-7", attributes);
+
+        // when
+        interceptor.preSend(message, channel);
+
+        // then
+        Object subscriptions = attributes.get(WebSocketAuthInterceptor.ARTRUN_SUBSCRIPTIONS);
+        assertThat(subscriptions).isInstanceOf(Map.class);
+        assertThat((Map<String, Long>) subscriptions).containsEntry("sub-7", 100L);
+    }
+
+    @Test
+    @DisplayName("UNSUBSCRIBE 시 캐싱된 구독이 제거된다")
+    void unsubscribe_removesCachedSubscription() {
+        // given
+        Map<String, Long> subscriptions = new ConcurrentHashMap<>();
+        subscriptions.put("sub-7", 100L);
+        Map<String, Object> attributes = new HashMap<>();
+        attributes.put(WebSocketAuthInterceptor.ARTRUN_SUBSCRIPTIONS, subscriptions);
+
+        StompHeaderAccessor accessor = StompHeaderAccessor.create(StompCommand.UNSUBSCRIBE);
+        accessor.setSubscriptionId("sub-7");
+        accessor.setSessionAttributes(attributes);
+        accessor.setSessionId("test-session");
+        Message<?> message = MessageBuilder.createMessage(new byte[0], accessor.getMessageHeaders());
+
+        // when
+        interceptor.preSend(message, channel);
+
+        // then
+        assertThat(subscriptions).doesNotContainKey("sub-7");
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> #45 

## 📝작업 내용

협동 러닝 실시간 위치 공유의 구독 후 권한 회수와 발행 검증 캐싱을 구현했습니다.

- 탈퇴/세션 삭제 시 /topic/artrun/{sessionId}로 종료·이탈 이벤트 발행 → 클라이언트가 구독 해제 (협조형)
- 도메인 이벤트(ApplicationEvent) + @TransactionalEventListener로 처리 → 서비스를 WebSocket 메시징과 분리, 커밋 후에만 발행
- 구독 시 검증한 참가 정보를 WS 세션 속성에 캐싱 → 발행 시 DB 조회 제거, UNSUBSCRIBE 시 캐시 제거
- 구독/상태변경/삭제/탈퇴 모두 세션 row 비관적 락으로 직렬화

## 📷스크린샷 
<img width="1894" height="947" alt="스크린샷 2026-06-04 오후 10 16 01" src="https://github.com/user-attachments/assets/0f11def5-fbb3-4ce6-87f8-623ae75eea15" />
