### PR TITLE
[Feat] 받은 친구 요청 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
@@ -1,6 +1,7 @@
 package com._s3k.runsync.domain.friend.controller;
 
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
+import com._s3k.runsync.domain.friend.dto.response.ReceivedFriendRequestRes;
 import com._s3k.runsync.domain.friend.service.FriendService;
 import com._s3k.runsync.global.common.dto.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -23,5 +24,12 @@ public class FriendController {
     public CommonResponse<List<FriendListRes>> getFriends(
             @AuthenticationPrincipal Long userId) {
         return CommonResponse.success(friendService.getFriendsByUserId(userId));
+    }
+
+    @Operation(summary = "받은 친구 요청 목록 조회", description = "내가 받은 PENDING 상태의 친구 요청 목록 조회. 로그인 필요")
+    @GetMapping("/requests/received")
+    public CommonResponse<List<ReceivedFriendRequestRes>> getReceivedFriendRequests(
+            @AuthenticationPrincipal Long userId) {
+        return CommonResponse.success(friendService.getReceivedFriendRequests(userId));
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/friend/dto/response/ReceivedFriendRequestRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/dto/response/ReceivedFriendRequestRes.java
@@ -1,0 +1,47 @@
+package com._s3k.runsync.domain.friend.dto.response;
+
+import com._s3k.runsync.entity.FriendRequest;
+import com._s3k.runsync.entity.enums.FriendRequestStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Schema(description = "받은 친구 요청 응답")
+public class ReceivedFriendRequestRes {
+
+    @Schema(description = "친구 요청 ID", example = "1")
+    private Long requestId;
+
+    @Schema(description = "요청 보낸 사용자 ID", example = "2")
+    private Long senderId;
+
+    @Schema(description = "요청 보낸 사용자 닉네임", example = "runner123")
+    private String senderNickname;
+
+    @Schema(description = "요청 상태", example = "PENDING")
+    private FriendRequestStatus status;
+
+    @Schema(description = "요청 생성 시각", example = "2026-06-01T10:00:00")
+    private LocalDateTime createdAt;
+
+    private ReceivedFriendRequestRes(Long requestId, Long senderId, String senderNickname,
+                                     FriendRequestStatus status, LocalDateTime createdAt) {
+        this.requestId = requestId;
+        this.senderId = senderId;
+        this.senderNickname = senderNickname;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+
+    public static ReceivedFriendRequestRes of(FriendRequest friendRequest) {
+        return new ReceivedFriendRequestRes(
+                friendRequest.getId(),
+                friendRequest.getSender().getId(),
+                friendRequest.getSender().getNickname(),
+                friendRequest.getStatus(),
+                friendRequest.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
@@ -11,5 +11,5 @@ public interface FriendRequestRepository extends JpaRepository<FriendRequest, Lo
     boolean existsBySender_IdAndReceiver_IdAndStatus(Long senderId, Long receiverId, FriendRequestStatus status);
 
     @EntityGraph(attributePaths = {"sender"})
-    List<FriendRequest> findByReceiver_IdAndStatus(Long receiverId, FriendRequestStatus status);
+    List<FriendRequest> findByReceiver_IdAndStatusOrderByCreatedAtDesc(Long receiverId, FriendRequestStatus status);
 }

--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
@@ -1,0 +1,11 @@
+package com._s3k.runsync.domain.friend.repository;
+
+import com._s3k.runsync.entity.FriendRequest;
+import com._s3k.runsync.entity.enums.FriendRequestStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
+    List<FriendRequest> findByReceiver_IdAndStatus(Long receiverId, FriendRequestStatus status);
+}

--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
@@ -2,11 +2,14 @@ package com._s3k.runsync.domain.friend.repository;
 
 import com._s3k.runsync.entity.FriendRequest;
 import com._s3k.runsync.entity.enums.FriendRequestStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
     boolean existsBySender_IdAndReceiver_IdAndStatus(Long senderId, Long receiverId, FriendRequestStatus status);
+
+    @EntityGraph(attributePaths = {"sender"})
     List<FriendRequest> findByReceiver_IdAndStatus(Long receiverId, FriendRequestStatus status);
 }

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -1,13 +1,17 @@
 package com._s3k.runsync.domain.friend.service;
 
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
+import com._s3k.runsync.domain.friend.dto.response.ReceivedFriendRequestRes;
+import com._s3k.runsync.domain.friend.repository.FriendRequestRepository;
 import com._s3k.runsync.domain.friend.repository.FriendshipRepository;
 import com._s3k.runsync.domain.run.repository.RunRecordRepository;
 import com._s3k.runsync.domain.run.repository.RunningSessionRepository;
+import com._s3k.runsync.entity.FriendRequest;
 import com._s3k.runsync.entity.RunRecord;
 import com._s3k.runsync.entity.RunningSession;
 import com._s3k.runsync.entity.User;
 import com._s3k.runsync.entity.enums.ActivityStatus;
+import com._s3k.runsync.entity.enums.FriendRequestStatus;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -26,8 +30,17 @@ import java.util.stream.Collectors;
 public class FriendService {
 
     private final FriendshipRepository friendshipRepository;
+    private final FriendRequestRepository friendRequestRepository;
     private final RunningSessionRepository runningSessionRepository;
     private final RunRecordRepository runRecordRepository;
+
+    @Transactional(readOnly = true)
+    public List<ReceivedFriendRequestRes> getReceivedFriendRequests(Long userId) {
+        return friendRequestRepository.findByReceiver_IdAndStatus(userId, FriendRequestStatus.PENDING)
+                .stream()
+                .map(ReceivedFriendRequestRes::of)
+                .toList();
+    }
 
     @Transactional(readOnly = true)
     public List<FriendListRes> getFriendsByUserId(Long userId) {

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -76,7 +76,7 @@ public class FriendService {
 
     @Transactional(readOnly = true)
     public List<ReceivedFriendRequestRes> getReceivedFriendRequests(Long userId) {
-        return friendRequestRepository.findByReceiver_IdAndStatus(userId, FriendRequestStatus.PENDING)
+        return friendRequestRepository.findByReceiver_IdAndStatusOrderByCreatedAtDesc(userId, FriendRequestStatus.PENDING)
                 .stream()
                 .map(ReceivedFriendRequestRes::of)
                 .toList();

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -177,7 +177,7 @@ class FriendServiceTest {
     @DisplayName("받은 PENDING 친구 요청이 없으면 빈 리스트 반환")
     void getReceivedFriendRequests_empty() {
         // given
-        given(friendRequestRepository.findByReceiver_IdAndStatus(1L, FriendRequestStatus.PENDING))
+        given(friendRequestRepository.findByReceiver_IdAndStatusOrderByCreatedAtDesc(1L, FriendRequestStatus.PENDING))
                 .willReturn(List.of());
 
         // when
@@ -201,7 +201,7 @@ class FriendServiceTest {
         given(friendRequest.getStatus()).willReturn(FriendRequestStatus.PENDING);
         given(friendRequest.getCreatedAt()).willReturn(LocalDateTime.of(2026, 6, 1, 10, 0));
 
-        given(friendRequestRepository.findByReceiver_IdAndStatus(1L, FriendRequestStatus.PENDING))
+        given(friendRequestRepository.findByReceiver_IdAndStatusOrderByCreatedAtDesc(1L, FriendRequestStatus.PENDING))
                 .willReturn(List.of(friendRequest));
 
         // when

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -1,13 +1,17 @@
 package com._s3k.runsync.domain.friend.service;
 
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
+import com._s3k.runsync.domain.friend.dto.response.ReceivedFriendRequestRes;
+import com._s3k.runsync.domain.friend.repository.FriendRequestRepository;
 import com._s3k.runsync.domain.friend.repository.FriendshipRepository;
 import com._s3k.runsync.domain.run.repository.RunRecordRepository;
 import com._s3k.runsync.domain.run.repository.RunningSessionRepository;
+import com._s3k.runsync.entity.FriendRequest;
 import com._s3k.runsync.entity.RunRecord;
 import com._s3k.runsync.entity.RunningSession;
 import com._s3k.runsync.entity.User;
 import com._s3k.runsync.entity.enums.ActivityStatus;
+import com._s3k.runsync.entity.enums.FriendRequestStatus;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -35,10 +39,56 @@ class FriendServiceTest {
     private FriendshipRepository friendshipRepository;
 
     @Mock
+    private FriendRequestRepository friendRequestRepository;
+
+    @Mock
     private RunningSessionRepository runningSessionRepository;
 
     @Mock
     private RunRecordRepository runRecordRepository;
+
+    @Test
+    @DisplayName("받은 PENDING 친구 요청이 없으면 빈 리스트 반환")
+    void getReceivedFriendRequests_empty() {
+        // given
+        given(friendRequestRepository.findByReceiver_IdAndStatus(1L, FriendRequestStatus.PENDING))
+                .willReturn(List.of());
+
+        // when
+        List<ReceivedFriendRequestRes> result = friendService.getReceivedFriendRequests(1L);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("받은 PENDING 친구 요청 목록 정상 반환")
+    void getReceivedFriendRequests_success() {
+        // given
+        User sender = mock(User.class);
+        given(sender.getId()).willReturn(2L);
+        given(sender.getNickname()).willReturn("runner123");
+
+        FriendRequest friendRequest = mock(FriendRequest.class);
+        given(friendRequest.getId()).willReturn(1L);
+        given(friendRequest.getSender()).willReturn(sender);
+        given(friendRequest.getStatus()).willReturn(FriendRequestStatus.PENDING);
+        given(friendRequest.getCreatedAt()).willReturn(LocalDateTime.of(2026, 6, 1, 10, 0));
+
+        given(friendRequestRepository.findByReceiver_IdAndStatus(1L, FriendRequestStatus.PENDING))
+                .willReturn(List.of(friendRequest));
+
+        // when
+        List<ReceivedFriendRequestRes> result = friendService.getReceivedFriendRequests(1L);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getRequestId()).isEqualTo(1L);
+        assertThat(result.get(0).getSenderId()).isEqualTo(2L);
+        assertThat(result.get(0).getSenderNickname()).isEqualTo("runner123");
+        assertThat(result.get(0).getStatus()).isEqualTo(FriendRequestStatus.PENDING);
+        assertThat(result.get(0).getCreatedAt()).isEqualTo(LocalDateTime.of(2026, 6, 1, 10, 0));
+    }
 
     @Test
     @DisplayName("친구가 없으면 빈 리스트 반환")


### PR DESCRIPTION
## Related Issue
  - Close #47

## Task
  - GET /api/friends/requests/received 엔드포인트 구현
  - PENDING 상태의 받은 친구 요청 목록만 반환
  - FriendRequestRepository 생성 (findByReceiver_IdAndStatus)
  - ReceivedFriendRequestRes DTO 생성 (requestId, senderId, senderNickname,
  status, createdAt)
  - FriendService.getReceivedFriendRequests() 구현
  - FriendServiceTest 단위 테스트 추가 (빈 리스트, 정상 반환)

## To Reviewer
  - PENDING 상태만 필터링하여 반환 — 수락/거절된 요청은 목록에서 제외
  - status 필드를 String 대신 FriendRequestStatus enum 타입으로 직접 반환
  (Jackson이 자동 직렬화)
  - FriendRequestRepository는 feature/34에서도 생성되어 머지 시 충돌 해결 완료

## Check List
  - [x] PR 제목 규칙 준수
  - [ ] 라벨과 리뷰어 설정
  - [x] 민감파일(*.yml 등) .gitignore 설정

<img width="1102" height="740" alt="image" src="https://github.com/user-attachments/assets/d7e133e1-29fa-462b-bc59-b7c33fe3e548" />
<img width="1076" height="341" alt="image" src="https://github.com/user-attachments/assets/315d2846-b1a8-4f67-8ba1-2888cadc7042" />
