### PR TITLE
[Feat] 보낸 친구 요청 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
@@ -2,6 +2,7 @@ package com._s3k.runsync.domain.friend.controller;
 
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
 import com._s3k.runsync.domain.friend.dto.response.ReceivedFriendRequestRes;
+import com._s3k.runsync.domain.friend.dto.response.SentFriendRequestRes;
 import com._s3k.runsync.domain.friend.service.FriendService;
 import com._s3k.runsync.global.common.dto.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -24,6 +25,13 @@ public class FriendController {
     public CommonResponse<List<FriendListRes>> getFriends(
             @AuthenticationPrincipal Long userId) {
         return CommonResponse.success(friendService.getFriendsByUserId(userId));
+    }
+
+    @Operation(summary = "보낸 친구 요청 목록 조회", description = "내가 보낸 PENDING 상태의 친구 요청 목록 조회. 로그인 필요")
+    @GetMapping("/requests/sent")
+    public CommonResponse<List<SentFriendRequestRes>> getSentFriendRequests(
+            @AuthenticationPrincipal Long userId) {
+        return CommonResponse.success(friendService.getSentFriendRequests(userId));
     }
 
     @Operation(summary = "받은 친구 요청 목록 조회", description = "내가 받은 PENDING 상태의 친구 요청 목록 조회. 로그인 필요")

--- a/src/main/java/com/_s3k/runsync/domain/friend/dto/response/SentFriendRequestRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/dto/response/SentFriendRequestRes.java
@@ -1,0 +1,47 @@
+package com._s3k.runsync.domain.friend.dto.response;
+
+import com._s3k.runsync.entity.FriendRequest;
+import com._s3k.runsync.entity.enums.FriendRequestStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Schema(description = "보낸 친구 요청 응답")
+public class SentFriendRequestRes {
+
+    @Schema(description = "친구 요청 ID", example = "11")
+    private Long requestId;
+
+    @Schema(description = "요청 받은 사용자 ID", example = "4")
+    private Long receiverId;
+
+    @Schema(description = "요청 받은 사용자 닉네임", example = "한현우")
+    private String receiverNickname;
+
+    @Schema(description = "요청 상태", example = "PENDING")
+    private FriendRequestStatus status;
+
+    @Schema(description = "요청 생성 시각", example = "2026-04-10T14:05:00")
+    private LocalDateTime createdAt;
+
+    private SentFriendRequestRes(Long requestId, Long receiverId, String receiverNickname,
+                                 FriendRequestStatus status, LocalDateTime createdAt) {
+        this.requestId = requestId;
+        this.receiverId = receiverId;
+        this.receiverNickname = receiverNickname;
+        this.status = status;
+        this.createdAt = createdAt;
+    }
+
+    public static SentFriendRequestRes of(FriendRequest friendRequest) {
+        return new SentFriendRequestRes(
+                friendRequest.getId(),
+                friendRequest.getReceiver().getId(),
+                friendRequest.getReceiver().getNickname(),
+                friendRequest.getStatus(),
+                friendRequest.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
@@ -2,11 +2,14 @@ package com._s3k.runsync.domain.friend.repository;
 
 import com._s3k.runsync.entity.FriendRequest;
 import com._s3k.runsync.entity.enums.FriendRequestStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
 
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
     List<FriendRequest> findByReceiver_IdAndStatus(Long receiverId, FriendRequestStatus status);
-    List<FriendRequest> findBySender_IdAndStatus(Long senderId, FriendRequestStatus status);
+
+    @EntityGraph(attributePaths = {"receiver"})
+    List<FriendRequest> findBySender_IdAndStatusOrderByCreatedAtDesc(Long senderId, FriendRequestStatus status);
 }

--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
@@ -8,4 +8,5 @@ import java.util.List;
 
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
     List<FriendRequest> findByReceiver_IdAndStatus(Long receiverId, FriendRequestStatus status);
+    List<FriendRequest> findBySender_IdAndStatus(Long senderId, FriendRequestStatus status);
 }

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -37,7 +37,7 @@ public class FriendService {
 
     @Transactional(readOnly = true)
     public List<SentFriendRequestRes> getSentFriendRequests(Long userId) {
-        return friendRequestRepository.findBySender_IdAndStatus(userId, FriendRequestStatus.PENDING)
+        return friendRequestRepository.findBySender_IdAndStatusOrderByCreatedAtDesc(userId, FriendRequestStatus.PENDING)
                 .stream()
                 .map(SentFriendRequestRes::of)
                 .toList();

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -2,6 +2,7 @@ package com._s3k.runsync.domain.friend.service;
 
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
 import com._s3k.runsync.domain.friend.dto.response.ReceivedFriendRequestRes;
+import com._s3k.runsync.domain.friend.dto.response.SentFriendRequestRes;
 import com._s3k.runsync.domain.friend.repository.FriendRequestRepository;
 import com._s3k.runsync.domain.friend.repository.FriendshipRepository;
 import com._s3k.runsync.domain.run.repository.RunRecordRepository;
@@ -33,6 +34,14 @@ public class FriendService {
     private final FriendRequestRepository friendRequestRepository;
     private final RunningSessionRepository runningSessionRepository;
     private final RunRecordRepository runRecordRepository;
+
+    @Transactional(readOnly = true)
+    public List<SentFriendRequestRes> getSentFriendRequests(Long userId) {
+        return friendRequestRepository.findBySender_IdAndStatus(userId, FriendRequestStatus.PENDING)
+                .stream()
+                .map(SentFriendRequestRes::of)
+                .toList();
+    }
 
     @Transactional(readOnly = true)
     public List<ReceivedFriendRequestRes> getReceivedFriendRequests(Long userId) {

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -2,6 +2,7 @@ package com._s3k.runsync.domain.friend.service;
 
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
 import com._s3k.runsync.domain.friend.dto.response.ReceivedFriendRequestRes;
+import com._s3k.runsync.domain.friend.dto.response.SentFriendRequestRes;
 import com._s3k.runsync.domain.friend.repository.FriendRequestRepository;
 import com._s3k.runsync.domain.friend.repository.FriendshipRepository;
 import com._s3k.runsync.domain.run.repository.RunRecordRepository;
@@ -46,6 +47,49 @@ class FriendServiceTest {
 
     @Mock
     private RunRecordRepository runRecordRepository;
+
+    @Test
+    @DisplayName("보낸 PENDING 친구 요청이 없으면 빈 리스트 반환")
+    void getSentFriendRequests_empty() {
+        // given
+        given(friendRequestRepository.findBySender_IdAndStatus(1L, FriendRequestStatus.PENDING))
+                .willReturn(List.of());
+
+        // when
+        List<SentFriendRequestRes> result = friendService.getSentFriendRequests(1L);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("보낸 PENDING 친구 요청 목록 정상 반환")
+    void getSentFriendRequests_success() {
+        // given
+        User receiver = mock(User.class);
+        given(receiver.getId()).willReturn(4L);
+        given(receiver.getNickname()).willReturn("한현우");
+
+        FriendRequest friendRequest = mock(FriendRequest.class);
+        given(friendRequest.getId()).willReturn(11L);
+        given(friendRequest.getReceiver()).willReturn(receiver);
+        given(friendRequest.getStatus()).willReturn(FriendRequestStatus.PENDING);
+        given(friendRequest.getCreatedAt()).willReturn(LocalDateTime.of(2026, 4, 10, 14, 5));
+
+        given(friendRequestRepository.findBySender_IdAndStatus(1L, FriendRequestStatus.PENDING))
+                .willReturn(List.of(friendRequest));
+
+        // when
+        List<SentFriendRequestRes> result = friendService.getSentFriendRequests(1L);
+
+        // then
+        assertThat(result).hasSize(1);
+        assertThat(result.get(0).getRequestId()).isEqualTo(11L);
+        assertThat(result.get(0).getReceiverId()).isEqualTo(4L);
+        assertThat(result.get(0).getReceiverNickname()).isEqualTo("한현우");
+        assertThat(result.get(0).getStatus()).isEqualTo(FriendRequestStatus.PENDING);
+        assertThat(result.get(0).getCreatedAt()).isEqualTo(LocalDateTime.of(2026, 4, 10, 14, 5));
+    }
 
     @Test
     @DisplayName("받은 PENDING 친구 요청이 없으면 빈 리스트 반환")

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -52,7 +52,7 @@ class FriendServiceTest {
     @DisplayName("보낸 PENDING 친구 요청이 없으면 빈 리스트 반환")
     void getSentFriendRequests_empty() {
         // given
-        given(friendRequestRepository.findBySender_IdAndStatus(1L, FriendRequestStatus.PENDING))
+        given(friendRequestRepository.findBySender_IdAndStatusOrderByCreatedAtDesc(1L, FriendRequestStatus.PENDING))
                 .willReturn(List.of());
 
         // when
@@ -76,7 +76,7 @@ class FriendServiceTest {
         given(friendRequest.getStatus()).willReturn(FriendRequestStatus.PENDING);
         given(friendRequest.getCreatedAt()).willReturn(LocalDateTime.of(2026, 4, 10, 14, 5));
 
-        given(friendRequestRepository.findBySender_IdAndStatus(1L, FriendRequestStatus.PENDING))
+        given(friendRequestRepository.findBySender_IdAndStatusOrderByCreatedAtDesc(1L, FriendRequestStatus.PENDING))
                 .willReturn(List.of(friendRequest));
 
         // when


### PR DESCRIPTION
## Related Issue
  - Close #49

## Task
  - `GET /api/friends/requests/sent` 엔드포인트 구현
  - PENDING 상태의 보낸 친구 요청 목록 반환 (requestId, receiverId,
  receiverNickname, status, createdAt)
  - `SentFriendRequestRes` DTO 분리 (발신 관점 전용 필드 구성)
  - `@EntityGraph({"receiver"})` 적용으로 N+1 방지
  - `findBySender_IdAndStatusOrderByCreatedAtDesc` 파생 쿼리로 DB 레벨 내림차순
  정렬

## To Reviewer
  - `FriendRequestRepository`에 `@EntityGraph({"receiver"})` 지정: 발신자로
  필터링하는 쿼리이므로 수신자(`receiver`)만 JOIN FETCH — 이미 조건에 사용된
  `sender` 쪽은 별도 JOIN 불필요
  - `SentFriendRequestRes`와 `ReceivedFriendRequestRes`를 별도 DTO로 분리한 이유:
  발신 관점(receiverId, receiverNickname)과 수신 관점(senderId, senderNickname)의
  노출 필드가 달라 단일 DTO로 합치면 책임 혼재

## Reference
  - #47 받은 친구 요청 목록 조회 API

## Check List
  - [ ] PR 제목 규칙 준수
  - [ ] 라벨과 리뷰어 설정
  - [ ] 민감파일(*.yml 등) .gitignore 설정