### PR TITLE
[Feat] 친구 요청 수락 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
@@ -1,6 +1,7 @@
 package com._s3k.runsync.domain.friend.controller;
 
 import com._s3k.runsync.domain.friend.dto.request.FriendRequestReq;
+import com._s3k.runsync.domain.friend.dto.response.FriendAcceptRes;
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
 import com._s3k.runsync.domain.friend.dto.response.FriendRequestRes;
 import com._s3k.runsync.domain.friend.dto.response.ReceivedFriendRequestRes;
@@ -13,6 +14,8 @@ import lombok.RequiredArgsConstructor;
 import java.util.List;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,6 +34,14 @@ public class FriendController {
             @AuthenticationPrincipal Long userId,
             @Valid @RequestBody FriendRequestReq req) {
         return CommonResponse.success(friendService.createFriendRequest(userId, req));
+    }
+
+    @Operation(summary = "친구 요청 수락", description = "받은 친구 요청 수락. 로그인 필요")
+    @PatchMapping("/requests/{requestId}/accept")
+    public CommonResponse<FriendAcceptRes> acceptFriendRequest(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long requestId) {
+        return CommonResponse.success(friendService.acceptFriendRequest(userId, requestId));
     }
 
     @Operation(summary = "친구 목록 조회", description = "친구 목록 및 활동 상태 조회. 로그인 필요")

--- a/src/main/java/com/_s3k/runsync/domain/friend/dto/response/FriendAcceptRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/dto/response/FriendAcceptRes.java
@@ -1,0 +1,26 @@
+package com._s3k.runsync.domain.friend.dto.response;
+
+import com._s3k.runsync.entity.FriendRequest;
+import com._s3k.runsync.entity.enums.FriendRequestStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "친구 요청 수락 응답")
+public class FriendAcceptRes {
+
+    @Schema(description = "친구 요청 ID", example = "10")
+    private Long requestId;
+
+    @Schema(description = "요청 상태", example = "ACCEPTED")
+    private FriendRequestStatus status;
+
+    private FriendAcceptRes(Long requestId, FriendRequestStatus status) {
+        this.requestId = requestId;
+        this.status = status;
+    }
+
+    public static FriendAcceptRes of(FriendRequest friendRequest) {
+        return new FriendAcceptRes(friendRequest.getId(), friendRequest.getStatus());
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/friend/exception/FriendErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/exception/FriendErrorCode.java
@@ -13,7 +13,9 @@ public enum FriendErrorCode implements ResultCode {
 
     FRIEND_SELF_REQUEST(HttpStatus.BAD_REQUEST, 6000, "자기 자신에게 친구 요청을 보낼 수 없습니다."),
     FRIEND_REQUEST_ALREADY_SENT(HttpStatus.CONFLICT, 6001, "이미 친구 요청을 보냈습니다."),
-    FRIEND_ALREADY_EXISTS(HttpStatus.CONFLICT, 6002, "이미 친구 관계입니다.");
+    FRIEND_ALREADY_EXISTS(HttpStatus.CONFLICT, 6002, "이미 친구 관계입니다."),
+    FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, 6003, "친구 요청을 찾을 수 없습니다."),
+    FRIEND_REQUEST_ALREADY_PROCESSED(HttpStatus.CONFLICT, 6004, "이미 처리된 친구 요청입니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/domain/friend/exception/FriendErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/exception/FriendErrorCode.java
@@ -15,7 +15,8 @@ public enum FriendErrorCode implements ResultCode {
     FRIEND_REQUEST_ALREADY_SENT(HttpStatus.CONFLICT, 6001, "이미 친구 요청을 보냈습니다."),
     FRIEND_ALREADY_EXISTS(HttpStatus.CONFLICT, 6002, "이미 친구 관계입니다."),
     FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, 6003, "친구 요청을 찾을 수 없습니다."),
-    FRIEND_REQUEST_ALREADY_PROCESSED(HttpStatus.CONFLICT, 6004, "이미 처리된 친구 요청입니다.");
+    FRIEND_REQUEST_ALREADY_PROCESSED(HttpStatus.CONFLICT, 6004, "이미 처리된 친구 요청입니다."),
+    FRIEND_REQUEST_RECEIVED(HttpStatus.CONFLICT, 6005, "상대방에게서 받은 친구 요청이 있습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
@@ -6,8 +6,13 @@ import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
+    @Override
+    @EntityGraph(attributePaths = {"sender", "receiver"})
+    Optional<FriendRequest> findById(Long id);
+
     boolean existsBySender_IdAndReceiver_IdAndStatus(Long senderId, Long receiverId, FriendRequestStatus status);
 
     @EntityGraph(attributePaths = {"sender"})

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -1,6 +1,7 @@
 package com._s3k.runsync.domain.friend.service;
 
 import com._s3k.runsync.domain.friend.dto.request.FriendRequestReq;
+import com._s3k.runsync.domain.friend.dto.response.FriendAcceptRes;
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
 import com._s3k.runsync.domain.friend.dto.response.FriendRequestRes;
 import com._s3k.runsync.domain.friend.dto.response.ReceivedFriendRequestRes;
@@ -19,6 +20,7 @@ import com._s3k.runsync.entity.User;
 import com._s3k.runsync.entity.enums.ActivityStatus;
 import com._s3k.runsync.entity.enums.FriendRequestStatus;
 import com._s3k.runsync.entity.enums.RunningSessionStatus;
+import com._s3k.runsync.entity.Friendship;
 import com._s3k.runsync.global.exception.GlobalException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -73,6 +75,26 @@ public class FriendService {
         } catch (DataIntegrityViolationException e) {
             throw new GlobalException(FriendErrorCode.FRIEND_REQUEST_ALREADY_SENT);
         }
+    }
+
+    @Transactional
+    public FriendAcceptRes acceptFriendRequest(Long userId, Long requestId) {
+        FriendRequest friendRequest = friendRequestRepository.findById(requestId)
+                .filter(r -> r.getReceiver().getId().equals(userId))
+                .orElseThrow(() -> new GlobalException(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND));
+
+        if (friendRequest.getStatus() != FriendRequestStatus.PENDING) {
+            throw new GlobalException(FriendErrorCode.FRIEND_REQUEST_ALREADY_PROCESSED);
+        }
+
+        friendRequest.accept();
+
+        User sender = friendRequest.getSender();
+        User receiver = friendRequest.getReceiver();
+        friendshipRepository.save(Friendship.of(receiver, sender));
+        friendshipRepository.save(Friendship.of(sender, receiver));
+
+        return FriendAcceptRes.of(friendRequest);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -65,6 +65,10 @@ public class FriendService {
             throw new GlobalException(FriendErrorCode.FRIEND_REQUEST_ALREADY_SENT);
         }
 
+        if (friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(receiverId, senderId, FriendRequestStatus.PENDING)) {
+            throw new GlobalException(FriendErrorCode.FRIEND_REQUEST_RECEIVED);
+        }
+
         if (friendshipRepository.existsByUser_IdAndFriend_Id(senderId, receiverId)) {
             throw new GlobalException(FriendErrorCode.FRIEND_ALREADY_EXISTS);
         }

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -91,8 +91,17 @@ public class FriendService {
 
         User sender = friendRequest.getSender();
         User receiver = friendRequest.getReceiver();
-        friendshipRepository.save(Friendship.of(receiver, sender));
-        friendshipRepository.save(Friendship.of(sender, receiver));
+
+        if (friendshipRepository.existsByUser_IdAndFriend_Id(sender.getId(), receiver.getId())) {
+            throw new GlobalException(FriendErrorCode.FRIEND_ALREADY_EXISTS);
+        }
+
+        try {
+            friendshipRepository.save(Friendship.of(receiver, sender));
+            friendshipRepository.save(Friendship.of(sender, receiver));
+        } catch (DataIntegrityViolationException e) {
+            throw new GlobalException(FriendErrorCode.FRIEND_ALREADY_EXISTS);
+        }
 
         return FriendAcceptRes.of(friendRequest);
     }

--- a/src/main/java/com/_s3k/runsync/entity/FriendRequest.java
+++ b/src/main/java/com/_s3k/runsync/entity/FriendRequest.java
@@ -40,4 +40,8 @@ public class FriendRequest extends BaseEntity {
                 .status(FriendRequestStatus.PENDING)
                 .build();
     }
+
+    public void accept() {
+        this.status = FriendRequestStatus.ACCEPTED;
+    }
 }

--- a/src/main/java/com/_s3k/runsync/entity/Friendship.java
+++ b/src/main/java/com/_s3k/runsync/entity/Friendship.java
@@ -7,7 +7,8 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "friendship")
+@Table(name = "friendship",
+        uniqueConstraints = @UniqueConstraint(columnNames = {"user_id", "friend_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Friendship extends BaseEntity {

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -1,6 +1,7 @@
 package com._s3k.runsync.domain.friend.service;
 
 import com._s3k.runsync.domain.friend.dto.request.FriendRequestReq;
+import com._s3k.runsync.domain.friend.dto.response.FriendAcceptRes;
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
 import com._s3k.runsync.domain.friend.dto.response.FriendRequestRes;
 import com._s3k.runsync.domain.friend.dto.response.ReceivedFriendRequestRes;
@@ -384,5 +385,80 @@ class FriendServiceTest {
         assertThat(result.get(1).getFriendUserId()).isEqualTo(2L); // OFFLINE, 최신 기록
         assertThat(result.get(2).getFriendUserId()).isEqualTo(3L); // OFFLINE, 오래된 기록
         assertThat(result.get(3).getFriendUserId()).isEqualTo(4L); // OFFLINE, 기록 없음
+    }
+
+    @Test
+    @DisplayName("친구 요청 정상 수락 - Friendship 양방향 저장, ACCEPTED 반환")
+    void acceptFriendRequest_success() {
+        // given
+        User sender = mock(User.class);
+        User receiver = mock(User.class);
+        given(receiver.getId()).willReturn(1L);
+
+        FriendRequest friendRequest = mock(FriendRequest.class);
+        given(friendRequest.getId()).willReturn(10L);
+        given(friendRequest.getReceiver()).willReturn(receiver);
+        given(friendRequest.getSender()).willReturn(sender);
+        given(friendRequest.getStatus())
+                .willReturn(FriendRequestStatus.PENDING)
+                .willReturn(FriendRequestStatus.ACCEPTED);
+        given(friendRequestRepository.findById(10L)).willReturn(Optional.of(friendRequest));
+
+        // when
+        FriendAcceptRes result = friendService.acceptFriendRequest(1L, 10L);
+
+        // then
+        assertThat(result.getRequestId()).isEqualTo(10L);
+        assertThat(result.getStatus()).isEqualTo(FriendRequestStatus.ACCEPTED);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 친구 요청 수락 시 FRIEND_REQUEST_NOT_FOUND 예외 발생")
+    void acceptFriendRequest_notFound() {
+        // given
+        given(friendRequestRepository.findById(10L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> friendService.acceptFriendRequest(1L, 10L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("receiver가 아닌 사용자가 수락 시도 시 FRIEND_REQUEST_NOT_FOUND 예외 발생")
+    void acceptFriendRequest_notReceiver() {
+        // given
+        User receiver = mock(User.class);
+        given(receiver.getId()).willReturn(99L);
+
+        FriendRequest friendRequest = mock(FriendRequest.class);
+        given(friendRequest.getReceiver()).willReturn(receiver);
+        given(friendRequestRepository.findById(10L)).willReturn(Optional.of(friendRequest));
+
+        // when & then
+        assertThatThrownBy(() -> friendService.acceptFriendRequest(1L, 10L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("이미 처리된 친구 요청 수락 시 FRIEND_REQUEST_ALREADY_PROCESSED 예외 발생")
+    void acceptFriendRequest_alreadyProcessed() {
+        // given
+        User receiver = mock(User.class);
+        given(receiver.getId()).willReturn(1L);
+
+        FriendRequest friendRequest = mock(FriendRequest.class);
+        given(friendRequest.getReceiver()).willReturn(receiver);
+        given(friendRequest.getStatus()).willReturn(FriendRequestStatus.ACCEPTED);
+        given(friendRequestRepository.findById(10L)).willReturn(Optional.of(friendRequest));
+
+        // when & then
+        assertThatThrownBy(() -> friendService.acceptFriendRequest(1L, 10L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(FriendErrorCode.FRIEND_REQUEST_ALREADY_PROCESSED));
     }
 }

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -156,6 +156,26 @@ class FriendServiceTest {
     }
 
     @Test
+    @DisplayName("상대방에게서 받은 PENDING 요청이 있으면 FRIEND_REQUEST_RECEIVED 예외 발생")
+    void createFriendRequest_reverseRequestExists() {
+        // given
+        FriendRequestReq req = FriendRequestReq.of(2L);
+
+        User sender = mock(User.class);
+        User receiver = mock(User.class);
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(1L, 2L, FriendRequestStatus.PENDING)).willReturn(false);
+        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(2L, 1L, FriendRequestStatus.PENDING)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> friendService.createFriendRequest(1L, req))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(FriendErrorCode.FRIEND_REQUEST_RECEIVED));
+    }
+
+    @Test
     @DisplayName("이미 친구 관계이면 FRIEND_ALREADY_EXISTS 예외 발생")
     void createFriendRequest_alreadyFriends() {
         // given


### PR DESCRIPTION
## Related Issue
  - Close #52

## Task
  - `PATCH /api/friends/requests/{requestId}/accept` 엔드포인트 구현
  - `FriendErrorCode` 에러코드 추가 (FRIEND_REQUEST_NOT_FOUND: 6003,
  FRIEND_REQUEST_ALREADY_PROCESSED: 6004)
  - `FriendRequest.accept()` 엔티티 행위 메서드 추가 (dirty checking UPDATE 방식)
  - `FriendAcceptRes` 응답 DTO 신규 생성 (requestId, status)
  - `FriendRequestRepository.findById` @EntityGraph({"sender","receiver"})
  오버라이드 — N+1 방지
  - `Friendship` 양방향 저장 (receiver→sender, sender→receiver)
  - receiver 권한 검증 — receiver가 아닌 사용자 수락 시도 시
  FRIEND_REQUEST_NOT_FOUND 반환 (보안 패턴)

## To Reviewer
  - `FriendRequest.accept()` + `@Transactional` 조합으로 별도 `save()` 없이 JPA
  변경감지가 자동 UPDATE 실행 — 복합 유니크 제약 `(sender_id, receiver_id,
  status)` 안전 유지
  - receiver 권한 검증 실패 시 403 대신 `FRIEND_REQUEST_NOT_FOUND(404)` 반환 —
  요청 존재 여부를 노출하지 않아 타인 요청 탐색 차단
  - `findById` @EntityGraph 오버라이드: sender(Friendship 생성)와 receiver(권한
  검증) 둘 다 필요해 두 연관관계를 한 쿼리로 로딩

## Reference
  - #34 친구 요청 보내기 API
  - #47 받은 친구 요청 목록 조회 API

## Check List
  - [ ] PR 제목 규칙 준수
  - [ ] 라벨과 리뷰어 설정
  - [ ] 민감파일(*.yml 등) .gitignore 설정

<img width="888" height="858" alt="image" src="https://github.com/user-attachments/assets/e38954f1-d371-41c5-b990-2f8ea2dc05bb" />
<img width="890" height="291" alt="image" src="https://github.com/user-attachments/assets/b74c8e8e-8d5a-4adc-97aa-8ebeef65cacd" />
