### PR TITLE
[Feat] 친구 요청 거절 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
@@ -2,6 +2,7 @@ package com._s3k.runsync.domain.friend.controller;
 
 import com._s3k.runsync.domain.friend.dto.request.FriendRequestReq;
 import com._s3k.runsync.domain.friend.dto.response.FriendAcceptRes;
+import com._s3k.runsync.domain.friend.dto.response.FriendRejectRes;
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
 import com._s3k.runsync.domain.friend.dto.response.FriendRequestRes;
 import com._s3k.runsync.domain.friend.dto.response.ReceivedFriendRequestRes;
@@ -42,6 +43,14 @@ public class FriendController {
             @AuthenticationPrincipal Long userId,
             @PathVariable Long requestId) {
         return CommonResponse.success(friendService.acceptFriendRequest(userId, requestId));
+    }
+
+    @Operation(summary = "친구 요청 거절", description = "받은 친구 요청 거절. 로그인 필요")
+    @PatchMapping("/requests/{requestId}/reject")
+    public CommonResponse<FriendRejectRes> rejectFriendRequest(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long requestId) {
+        return CommonResponse.success(friendService.rejectFriendRequest(userId, requestId));
     }
 
     @Operation(summary = "친구 목록 조회", description = "친구 목록 및 활동 상태 조회. 로그인 필요")

--- a/src/main/java/com/_s3k/runsync/domain/friend/dto/response/FriendRejectRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/dto/response/FriendRejectRes.java
@@ -1,0 +1,26 @@
+package com._s3k.runsync.domain.friend.dto.response;
+
+import com._s3k.runsync.entity.FriendRequest;
+import com._s3k.runsync.entity.enums.FriendRequestStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "친구 요청 거절 응답")
+public class FriendRejectRes {
+
+    @Schema(description = "친구 요청 ID", example = "10")
+    private Long requestId;
+
+    @Schema(description = "요청 상태", example = "REJECTED")
+    private FriendRequestStatus status;
+
+    private FriendRejectRes(Long requestId, FriendRequestStatus status) {
+        this.requestId = requestId;
+        this.status = status;
+    }
+
+    public static FriendRejectRes of(FriendRequest friendRequest) {
+        return new FriendRejectRes(friendRequest.getId(), friendRequest.getStatus());
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/friend/exception/FriendErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/exception/FriendErrorCode.java
@@ -15,7 +15,8 @@ public enum FriendErrorCode implements ResultCode {
     FRIEND_REQUEST_ALREADY_SENT(HttpStatus.CONFLICT, 6001, "이미 친구 요청을 보냈습니다."),
     FRIEND_ALREADY_EXISTS(HttpStatus.CONFLICT, 6002, "이미 친구 관계입니다."),
     FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, 6003, "친구 요청을 찾을 수 없습니다."),
-    FRIEND_REQUEST_ALREADY_PROCESSED(HttpStatus.CONFLICT, 6004, "이미 처리된 친구 요청입니다.");
+    FRIEND_REQUEST_ALREADY_PROCESSED(HttpStatus.CONFLICT, 6004, "이미 처리된 친구 요청입니다."),
+    FRIEND_REQUEST_RECEIVED(HttpStatus.CONFLICT, 6005, "상대방에게서 받은 친구 요청이 있습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
@@ -9,11 +9,13 @@ import java.util.List;
 import java.util.Optional;
 
 public interface FriendRequestRepository extends JpaRepository<FriendRequest, Long> {
-    @Override
-    @EntityGraph(attributePaths = {"sender", "receiver"})
-    Optional<FriendRequest> findById(Long id);
 
     boolean existsBySender_IdAndReceiver_IdAndStatus(Long senderId, Long receiverId, FriendRequestStatus status);
+
+    Optional<FriendRequest> findBySender_IdAndReceiver_Id(Long senderId, Long receiverId);
+
+    @EntityGraph(attributePaths = {"sender", "receiver"})
+    Optional<FriendRequest> findByIdAndReceiver_Id(Long id, Long receiverId);
 
     @EntityGraph(attributePaths = {"sender"})
     List<FriendRequest> findByReceiver_IdAndStatusOrderByCreatedAtDesc(Long receiverId, FriendRequestStatus status);

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -66,6 +66,10 @@ public class FriendService {
             throw new GlobalException(FriendErrorCode.FRIEND_REQUEST_ALREADY_SENT);
         }
 
+        if (friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(receiverId, senderId, FriendRequestStatus.PENDING)) {
+            throw new GlobalException(FriendErrorCode.FRIEND_REQUEST_RECEIVED);
+        }
+
         if (friendshipRepository.existsByUser_IdAndFriend_Id(senderId, receiverId)) {
             throw new GlobalException(FriendErrorCode.FRIEND_ALREADY_EXISTS);
         }

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -2,6 +2,7 @@ package com._s3k.runsync.domain.friend.service;
 
 import com._s3k.runsync.domain.friend.dto.request.FriendRequestReq;
 import com._s3k.runsync.domain.friend.dto.response.FriendAcceptRes;
+import com._s3k.runsync.domain.friend.dto.response.FriendRejectRes;
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
 import com._s3k.runsync.domain.friend.dto.response.FriendRequestRes;
 import com._s3k.runsync.domain.friend.dto.response.ReceivedFriendRequestRes;
@@ -104,6 +105,20 @@ public class FriendService {
         }
 
         return FriendAcceptRes.of(friendRequest);
+    }
+
+    @Transactional
+    public FriendRejectRes rejectFriendRequest(Long userId, Long requestId) {
+        FriendRequest friendRequest = friendRequestRepository.findById(requestId)
+                .filter(r -> r.getReceiver().getId().equals(userId))
+                .orElseThrow(() -> new GlobalException(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND));
+
+        if (friendRequest.getStatus() != FriendRequestStatus.PENDING) {
+            throw new GlobalException(FriendErrorCode.FRIEND_REQUEST_ALREADY_PROCESSED);
+        }
+
+        friendRequest.reject();
+        return FriendRejectRes.of(friendRequest);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -33,6 +33,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -62,16 +63,22 @@ public class FriendService {
                 .filter(u -> !Boolean.TRUE.equals(u.getIsDeleted()))
                 .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
 
-        if (friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(senderId, receiverId, FriendRequestStatus.PENDING)) {
-            throw new GlobalException(FriendErrorCode.FRIEND_REQUEST_ALREADY_SENT);
-        }
-
         if (friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(receiverId, senderId, FriendRequestStatus.PENDING)) {
             throw new GlobalException(FriendErrorCode.FRIEND_REQUEST_RECEIVED);
         }
 
         if (friendshipRepository.existsByUser_IdAndFriend_Id(senderId, receiverId)) {
             throw new GlobalException(FriendErrorCode.FRIEND_ALREADY_EXISTS);
+        }
+
+        Optional<FriendRequest> existing = friendRequestRepository.findBySender_IdAndReceiver_Id(senderId, receiverId);
+        if (existing.isPresent()) {
+            FriendRequest existingRequest = existing.get();
+            if (existingRequest.getStatus() == FriendRequestStatus.PENDING) {
+                throw new GlobalException(FriendErrorCode.FRIEND_REQUEST_ALREADY_SENT);
+            }
+            existingRequest.resend();
+            return FriendRequestRes.of(existingRequest);
         }
 
         try {
@@ -84,8 +91,7 @@ public class FriendService {
 
     @Transactional
     public FriendAcceptRes acceptFriendRequest(Long userId, Long requestId) {
-        FriendRequest friendRequest = friendRequestRepository.findById(requestId)
-                .filter(r -> r.getReceiver().getId().equals(userId))
+        FriendRequest friendRequest = friendRequestRepository.findByIdAndReceiver_Id(requestId, userId)
                 .orElseThrow(() -> new GlobalException(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND));
 
         if (friendRequest.getStatus() != FriendRequestStatus.PENDING) {
@@ -113,8 +119,7 @@ public class FriendService {
 
     @Transactional
     public FriendRejectRes rejectFriendRequest(Long userId, Long requestId) {
-        FriendRequest friendRequest = friendRequestRepository.findById(requestId)
-                .filter(r -> r.getReceiver().getId().equals(userId))
+        FriendRequest friendRequest = friendRequestRepository.findByIdAndReceiver_Id(requestId, userId)
                 .orElseThrow(() -> new GlobalException(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND));
 
         if (friendRequest.getStatus() != FriendRequestStatus.PENDING) {

--- a/src/main/java/com/_s3k/runsync/entity/FriendRequest.java
+++ b/src/main/java/com/_s3k/runsync/entity/FriendRequest.java
@@ -44,4 +44,8 @@ public class FriendRequest extends BaseEntity {
     public void accept() {
         this.status = FriendRequestStatus.ACCEPTED;
     }
+
+    public void reject() {
+        this.status = FriendRequestStatus.REJECTED;
+    }
 }

--- a/src/main/java/com/_s3k/runsync/entity/FriendRequest.java
+++ b/src/main/java/com/_s3k/runsync/entity/FriendRequest.java
@@ -9,7 +9,7 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Table(name = "friend_requests",
-        uniqueConstraints = @UniqueConstraint(columnNames = {"sender_id", "receiver_id", "status"}))
+        uniqueConstraints = @UniqueConstraint(columnNames = {"sender_id", "receiver_id"}))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FriendRequest extends BaseEntity {
@@ -47,5 +47,9 @@ public class FriendRequest extends BaseEntity {
 
     public void reject() {
         this.status = FriendRequestStatus.REJECTED;
+    }
+
+    public void resend() {
+        this.status = FriendRequestStatus.PENDING;
     }
 }

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -2,6 +2,7 @@ package com._s3k.runsync.domain.friend.service;
 
 import com._s3k.runsync.domain.friend.dto.request.FriendRequestReq;
 import com._s3k.runsync.domain.friend.dto.response.FriendAcceptRes;
+import com._s3k.runsync.domain.friend.dto.response.FriendRejectRes;
 import com._s3k.runsync.domain.friend.dto.response.FriendListRes;
 import com._s3k.runsync.domain.friend.dto.response.FriendRequestRes;
 import com._s3k.runsync.domain.friend.dto.response.ReceivedFriendRequestRes;
@@ -457,6 +458,79 @@ class FriendServiceTest {
 
         // when & then
         assertThatThrownBy(() -> friendService.acceptFriendRequest(1L, 10L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(FriendErrorCode.FRIEND_REQUEST_ALREADY_PROCESSED));
+    }
+
+    @Test
+    @DisplayName("친구 요청 정상 거절 - REJECTED 반환")
+    void rejectFriendRequest_success() {
+        // given
+        User receiver = mock(User.class);
+        given(receiver.getId()).willReturn(1L);
+
+        FriendRequest friendRequest = mock(FriendRequest.class);
+        given(friendRequest.getId()).willReturn(10L);
+        given(friendRequest.getReceiver()).willReturn(receiver);
+        given(friendRequest.getStatus())
+                .willReturn(FriendRequestStatus.PENDING)
+                .willReturn(FriendRequestStatus.REJECTED);
+        given(friendRequestRepository.findById(10L)).willReturn(Optional.of(friendRequest));
+
+        // when
+        FriendRejectRes result = friendService.rejectFriendRequest(1L, 10L);
+
+        // then
+        assertThat(result.getRequestId()).isEqualTo(10L);
+        assertThat(result.getStatus()).isEqualTo(FriendRequestStatus.REJECTED);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 친구 요청 거절 시 FRIEND_REQUEST_NOT_FOUND 예외 발생")
+    void rejectFriendRequest_notFound() {
+        // given
+        given(friendRequestRepository.findById(10L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> friendService.rejectFriendRequest(1L, 10L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("receiver가 아닌 사용자가 거절 시도 시 FRIEND_REQUEST_NOT_FOUND 예외 발생")
+    void rejectFriendRequest_notReceiver() {
+        // given
+        User receiver = mock(User.class);
+        given(receiver.getId()).willReturn(99L);
+
+        FriendRequest friendRequest = mock(FriendRequest.class);
+        given(friendRequest.getReceiver()).willReturn(receiver);
+        given(friendRequestRepository.findById(10L)).willReturn(Optional.of(friendRequest));
+
+        // when & then
+        assertThatThrownBy(() -> friendService.rejectFriendRequest(1L, 10L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(FriendErrorCode.FRIEND_REQUEST_NOT_FOUND));
+    }
+
+    @Test
+    @DisplayName("이미 처리된 친구 요청 거절 시 FRIEND_REQUEST_ALREADY_PROCESSED 예외 발생")
+    void rejectFriendRequest_alreadyProcessed() {
+        // given
+        User receiver = mock(User.class);
+        given(receiver.getId()).willReturn(1L);
+
+        FriendRequest friendRequest = mock(FriendRequest.class);
+        given(friendRequest.getReceiver()).willReturn(receiver);
+        given(friendRequest.getStatus()).willReturn(FriendRequestStatus.REJECTED);
+        given(friendRequestRepository.findById(10L)).willReturn(Optional.of(friendRequest));
+
+        // when & then
+        assertThatThrownBy(() -> friendService.rejectFriendRequest(1L, 10L))
                 .isInstanceOf(GlobalException.class)
                 .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
                         .isEqualTo(FriendErrorCode.FRIEND_REQUEST_ALREADY_PROCESSED));

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -157,6 +157,26 @@ class FriendServiceTest {
     }
 
     @Test
+    @DisplayName("상대방에게서 받은 PENDING 요청이 있으면 FRIEND_REQUEST_RECEIVED 예외 발생")
+    void createFriendRequest_reverseRequestExists() {
+        // given
+        FriendRequestReq req = FriendRequestReq.of(2L);
+
+        User sender = mock(User.class);
+        User receiver = mock(User.class);
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(1L, 2L, FriendRequestStatus.PENDING)).willReturn(false);
+        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(2L, 1L, FriendRequestStatus.PENDING)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> friendService.createFriendRequest(1L, req))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(FriendErrorCode.FRIEND_REQUEST_RECEIVED));
+    }
+
+    @Test
     @DisplayName("이미 친구 관계이면 FRIEND_ALREADY_EXISTS 예외 발생")
     void createFriendRequest_alreadyFriends() {
         // given

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -72,8 +73,9 @@ class FriendServiceTest {
         User receiver = mock(User.class);
         given(userRepository.findById(1L)).willReturn(Optional.of(sender));
         given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
-        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(1L, 2L, FriendRequestStatus.PENDING)).willReturn(false);
+        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(2L, 1L, FriendRequestStatus.PENDING)).willReturn(false);
         given(friendshipRepository.existsByUser_IdAndFriend_Id(1L, 2L)).willReturn(false);
+        given(friendRequestRepository.findBySender_IdAndReceiver_Id(1L, 2L)).willReturn(Optional.empty());
 
         FriendRequest savedRequest = mock(FriendRequest.class);
         given(savedRequest.getId()).willReturn(1L);
@@ -85,6 +87,32 @@ class FriendServiceTest {
 
         // then
         assertThat(result.getRequestId()).isEqualTo(1L);
+        assertThat(result.getStatus()).isEqualTo(FriendRequestStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("거절된 친구 요청에 재요청 시 PENDING으로 업데이트")
+    void createFriendRequest_resend() {
+        // given
+        FriendRequestReq req = FriendRequestReq.of(2L);
+
+        User sender = mock(User.class);
+        User receiver = mock(User.class);
+        given(userRepository.findById(1L)).willReturn(Optional.of(sender));
+        given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
+        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(2L, 1L, FriendRequestStatus.PENDING)).willReturn(false);
+        given(friendshipRepository.existsByUser_IdAndFriend_Id(1L, 2L)).willReturn(false);
+
+        FriendRequest rejectedRequest = FriendRequest.of(sender, receiver);
+        rejectedRequest.reject();
+        ReflectionTestUtils.setField(rejectedRequest, "id", 5L);
+        given(friendRequestRepository.findBySender_IdAndReceiver_Id(1L, 2L)).willReturn(Optional.of(rejectedRequest));
+
+        // when
+        FriendRequestRes result = friendService.createFriendRequest(1L, req);
+
+        // then
+        assertThat(result.getRequestId()).isEqualTo(5L);
         assertThat(result.getStatus()).isEqualTo(FriendRequestStatus.PENDING);
     }
 
@@ -147,7 +175,11 @@ class FriendServiceTest {
         User receiver = mock(User.class);
         given(userRepository.findById(1L)).willReturn(Optional.of(sender));
         given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
-        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(1L, 2L, FriendRequestStatus.PENDING)).willReturn(true);
+        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(2L, 1L, FriendRequestStatus.PENDING)).willReturn(false);
+        given(friendshipRepository.existsByUser_IdAndFriend_Id(1L, 2L)).willReturn(false);
+
+        FriendRequest pendingRequest = FriendRequest.of(sender, receiver);
+        given(friendRequestRepository.findBySender_IdAndReceiver_Id(1L, 2L)).willReturn(Optional.of(pendingRequest));
 
         // when & then
         assertThatThrownBy(() -> friendService.createFriendRequest(1L, req))
@@ -166,7 +198,6 @@ class FriendServiceTest {
         User receiver = mock(User.class);
         given(userRepository.findById(1L)).willReturn(Optional.of(sender));
         given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
-        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(1L, 2L, FriendRequestStatus.PENDING)).willReturn(false);
         given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(2L, 1L, FriendRequestStatus.PENDING)).willReturn(true);
 
         // when & then
@@ -186,7 +217,7 @@ class FriendServiceTest {
         User receiver = mock(User.class);
         given(userRepository.findById(1L)).willReturn(Optional.of(sender));
         given(userRepository.findById(2L)).willReturn(Optional.of(receiver));
-        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(1L, 2L, FriendRequestStatus.PENDING)).willReturn(false);
+        given(friendRequestRepository.existsBySender_IdAndReceiver_IdAndStatus(2L, 1L, FriendRequestStatus.PENDING)).willReturn(false);
         given(friendshipRepository.existsByUser_IdAndFriend_Id(1L, 2L)).willReturn(true);
 
         // when & then
@@ -414,16 +445,14 @@ class FriendServiceTest {
         // given
         User sender = mock(User.class);
         User receiver = mock(User.class);
+        given(sender.getId()).willReturn(2L);
         given(receiver.getId()).willReturn(1L);
 
-        FriendRequest friendRequest = mock(FriendRequest.class);
-        given(friendRequest.getId()).willReturn(10L);
-        given(friendRequest.getReceiver()).willReturn(receiver);
-        given(friendRequest.getSender()).willReturn(sender);
-        given(friendRequest.getStatus())
-                .willReturn(FriendRequestStatus.PENDING)
-                .willReturn(FriendRequestStatus.ACCEPTED);
-        given(friendRequestRepository.findById(10L)).willReturn(Optional.of(friendRequest));
+        FriendRequest friendRequest = FriendRequest.of(sender, receiver);
+        ReflectionTestUtils.setField(friendRequest, "id", 10L);
+
+        given(friendRequestRepository.findByIdAndReceiver_Id(10L, 1L)).willReturn(Optional.of(friendRequest));
+        given(friendshipRepository.existsByUser_IdAndFriend_Id(2L, 1L)).willReturn(false);
 
         // when
         FriendAcceptRes result = friendService.acceptFriendRequest(1L, 10L);
@@ -437,7 +466,7 @@ class FriendServiceTest {
     @DisplayName("존재하지 않는 친구 요청 수락 시 FRIEND_REQUEST_NOT_FOUND 예외 발생")
     void acceptFriendRequest_notFound() {
         // given
-        given(friendRequestRepository.findById(10L)).willReturn(Optional.empty());
+        given(friendRequestRepository.findByIdAndReceiver_Id(10L, 1L)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> friendService.acceptFriendRequest(1L, 10L))
@@ -450,12 +479,7 @@ class FriendServiceTest {
     @DisplayName("receiver가 아닌 사용자가 수락 시도 시 FRIEND_REQUEST_NOT_FOUND 예외 발생")
     void acceptFriendRequest_notReceiver() {
         // given
-        User receiver = mock(User.class);
-        given(receiver.getId()).willReturn(99L);
-
-        FriendRequest friendRequest = mock(FriendRequest.class);
-        given(friendRequest.getReceiver()).willReturn(receiver);
-        given(friendRequestRepository.findById(10L)).willReturn(Optional.of(friendRequest));
+        given(friendRequestRepository.findByIdAndReceiver_Id(10L, 1L)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> friendService.acceptFriendRequest(1L, 10L))
@@ -468,13 +492,9 @@ class FriendServiceTest {
     @DisplayName("이미 처리된 친구 요청 수락 시 FRIEND_REQUEST_ALREADY_PROCESSED 예외 발생")
     void acceptFriendRequest_alreadyProcessed() {
         // given
-        User receiver = mock(User.class);
-        given(receiver.getId()).willReturn(1L);
-
         FriendRequest friendRequest = mock(FriendRequest.class);
-        given(friendRequest.getReceiver()).willReturn(receiver);
         given(friendRequest.getStatus()).willReturn(FriendRequestStatus.ACCEPTED);
-        given(friendRequestRepository.findById(10L)).willReturn(Optional.of(friendRequest));
+        given(friendRequestRepository.findByIdAndReceiver_Id(10L, 1L)).willReturn(Optional.of(friendRequest));
 
         // when & then
         assertThatThrownBy(() -> friendService.acceptFriendRequest(1L, 10L))
@@ -487,16 +507,13 @@ class FriendServiceTest {
     @DisplayName("친구 요청 정상 거절 - REJECTED 반환")
     void rejectFriendRequest_success() {
         // given
+        User sender = mock(User.class);
         User receiver = mock(User.class);
-        given(receiver.getId()).willReturn(1L);
 
-        FriendRequest friendRequest = mock(FriendRequest.class);
-        given(friendRequest.getId()).willReturn(10L);
-        given(friendRequest.getReceiver()).willReturn(receiver);
-        given(friendRequest.getStatus())
-                .willReturn(FriendRequestStatus.PENDING)
-                .willReturn(FriendRequestStatus.REJECTED);
-        given(friendRequestRepository.findById(10L)).willReturn(Optional.of(friendRequest));
+        FriendRequest friendRequest = FriendRequest.of(sender, receiver);
+        ReflectionTestUtils.setField(friendRequest, "id", 10L);
+
+        given(friendRequestRepository.findByIdAndReceiver_Id(10L, 1L)).willReturn(Optional.of(friendRequest));
 
         // when
         FriendRejectRes result = friendService.rejectFriendRequest(1L, 10L);
@@ -510,7 +527,7 @@ class FriendServiceTest {
     @DisplayName("존재하지 않는 친구 요청 거절 시 FRIEND_REQUEST_NOT_FOUND 예외 발생")
     void rejectFriendRequest_notFound() {
         // given
-        given(friendRequestRepository.findById(10L)).willReturn(Optional.empty());
+        given(friendRequestRepository.findByIdAndReceiver_Id(10L, 1L)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> friendService.rejectFriendRequest(1L, 10L))
@@ -523,12 +540,7 @@ class FriendServiceTest {
     @DisplayName("receiver가 아닌 사용자가 거절 시도 시 FRIEND_REQUEST_NOT_FOUND 예외 발생")
     void rejectFriendRequest_notReceiver() {
         // given
-        User receiver = mock(User.class);
-        given(receiver.getId()).willReturn(99L);
-
-        FriendRequest friendRequest = mock(FriendRequest.class);
-        given(friendRequest.getReceiver()).willReturn(receiver);
-        given(friendRequestRepository.findById(10L)).willReturn(Optional.of(friendRequest));
+        given(friendRequestRepository.findByIdAndReceiver_Id(10L, 1L)).willReturn(Optional.empty());
 
         // when & then
         assertThatThrownBy(() -> friendService.rejectFriendRequest(1L, 10L))
@@ -541,13 +553,9 @@ class FriendServiceTest {
     @DisplayName("이미 처리된 친구 요청 거절 시 FRIEND_REQUEST_ALREADY_PROCESSED 예외 발생")
     void rejectFriendRequest_alreadyProcessed() {
         // given
-        User receiver = mock(User.class);
-        given(receiver.getId()).willReturn(1L);
-
         FriendRequest friendRequest = mock(FriendRequest.class);
-        given(friendRequest.getReceiver()).willReturn(receiver);
         given(friendRequest.getStatus()).willReturn(FriendRequestStatus.REJECTED);
-        given(friendRequestRepository.findById(10L)).willReturn(Optional.of(friendRequest));
+        given(friendRequestRepository.findByIdAndReceiver_Id(10L, 1L)).willReturn(Optional.of(friendRequest));
 
         // when & then
         assertThatThrownBy(() -> friendService.rejectFriendRequest(1L, 10L))


### PR DESCRIPTION
## Related Issue
  - Close #54

## Task
  - `PATCH /api/friends/requests/{requestId}/reject` 엔드포인트 구현
  - `FriendRequest.reject()` 엔티티 행위 메서드 추가 (dirty checking UPDATE 방식)
  - `FriendRejectRes` 응답 DTO 신규 생성 (requestId, status)
  - `FriendErrorCode` 에러코드 추가 (FRIEND_REQUEST_RECEIVED: 6005)
  - `createFriendRequest()` 에 역방향 PENDING 요청 차단 로직 추가 — A→B 요청 시
  B→A PENDING이 존재하면 FRIEND_REQUEST_RECEIVED 반환

## To Reviewer
  - `FriendRejectRes`를 `FriendAcceptRes` 재사용 대신 별도 DTO로 분리한 이유:
  수락/거절 응답 필드가 현재 동일하지만 이후 변경 시 서로 영향 없도록 분리 (S
  원칙)
  - 역방향 PENDING 차단은 보내기 단계(`createFriendRequest`)에서 처리 — 수락 시
  orphan 정리 대신 문제 원천 차단 방식 선택

## Reference
  - #52 친구 요청 수락 API

## Check List
  - [ ] PR 제목 규칙 준수
  - [ ] 라벨과 리뷰어 설정
  - [ ] 민감파일(*.yml 등) .gitignore 설정

<img width="949" height="854" alt="image" src="https://github.com/user-attachments/assets/f80161c3-5959-40d6-809a-c02684d92c53" />
<img width="952" height="281" alt="image" src="https://github.com/user-attachments/assets/c7d93afe-7e12-4ade-aed6-dd7ade2395e8" />
