### PR TITLE
[Feat] 친구 삭제 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
@@ -10,6 +10,7 @@ import com._s3k.runsync.domain.friend.dto.response.SentFriendRequestRes;
 import com._s3k.runsync.domain.friend.service.FriendService;
 import com._s3k.runsync.global.common.dto.CommonResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import java.util.List;
@@ -57,7 +58,9 @@ public class FriendController {
     @Operation(summary = "친구 삭제", description = "친구 관계 삭제. 로그인 필요")
     @DeleteMapping("/{friendUserId}")
     public CommonResponse<Void> deleteFriend(
+            @Parameter(description = "사용자 ID", required = true)
             @AuthenticationPrincipal Long userId,
+            @Parameter(description = "삭제할 친구 사용자 ID", required = true)
             @PathVariable Long friendUserId) {
         friendService.deleteFriend(userId, friendUserId);
         return CommonResponse.success(null);

--- a/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/controller/FriendController.java
@@ -14,6 +14,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import java.util.List;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -51,6 +52,15 @@ public class FriendController {
             @AuthenticationPrincipal Long userId,
             @PathVariable Long requestId) {
         return CommonResponse.success(friendService.rejectFriendRequest(userId, requestId));
+    }
+
+    @Operation(summary = "친구 삭제", description = "친구 관계 삭제. 로그인 필요")
+    @DeleteMapping("/{friendUserId}")
+    public CommonResponse<Void> deleteFriend(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long friendUserId) {
+        friendService.deleteFriend(userId, friendUserId);
+        return CommonResponse.success(null);
     }
 
     @Operation(summary = "친구 목록 조회", description = "친구 목록 및 활동 상태 조회. 로그인 필요")

--- a/src/main/java/com/_s3k/runsync/domain/friend/exception/FriendErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/exception/FriendErrorCode.java
@@ -16,7 +16,8 @@ public enum FriendErrorCode implements ResultCode {
     FRIEND_ALREADY_EXISTS(HttpStatus.CONFLICT, 6002, "이미 친구 관계입니다."),
     FRIEND_REQUEST_NOT_FOUND(HttpStatus.NOT_FOUND, 6003, "친구 요청을 찾을 수 없습니다."),
     FRIEND_REQUEST_ALREADY_PROCESSED(HttpStatus.CONFLICT, 6004, "이미 처리된 친구 요청입니다."),
-    FRIEND_REQUEST_RECEIVED(HttpStatus.CONFLICT, 6005, "상대방에게서 받은 친구 요청이 있습니다.");
+    FRIEND_REQUEST_RECEIVED(HttpStatus.CONFLICT, 6005, "상대방에게서 받은 친구 요청이 있습니다."),
+    FRIEND_NOT_FOUND(HttpStatus.NOT_FOUND, 6006, "친구 관계를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendshipRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendshipRepository.java
@@ -3,6 +3,7 @@ package com._s3k.runsync.domain.friend.repository;
 import com._s3k.runsync.entity.Friendship;
 import com._s3k.runsync.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -15,5 +16,7 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
 
     boolean existsByUser_IdAndFriend_Id(Long userId, Long friendId);
 
-    void deleteByUser_IdAndFriend_Id(Long userId, Long friendId);
+    @Modifying
+    @Query("DELETE FROM Friendship f WHERE (f.user.id = :userId AND f.friend.id = :friendId) OR (f.user.id = :friendId AND f.friend.id = :userId)")
+    void deleteFriendshipBidirectional(@Param("userId") Long userId, @Param("friendId") Long friendId);
 }

--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendshipRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendshipRepository.java
@@ -14,4 +14,6 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
     List<User> findFriendsByUserId(@Param("userId") Long userId);
 
     boolean existsByUser_IdAndFriend_Id(Long userId, Long friendId);
+
+    void deleteByUser_IdAndFriend_Id(Long userId, Long friendId);
 }

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -151,8 +151,7 @@ public class FriendService {
         if (!friendshipRepository.existsByUser_IdAndFriend_Id(userId, friendUserId)) {
             throw new GlobalException(FriendErrorCode.FRIEND_NOT_FOUND);
         }
-        friendshipRepository.deleteByUser_IdAndFriend_Id(userId, friendUserId);
-        friendshipRepository.deleteByUser_IdAndFriend_Id(friendUserId, userId);
+        friendshipRepository.deleteFriendshipBidirectional(userId, friendUserId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/service/FriendService.java
@@ -146,6 +146,15 @@ public class FriendService {
                 .toList();
     }
 
+    @Transactional
+    public void deleteFriend(Long userId, Long friendUserId) {
+        if (!friendshipRepository.existsByUser_IdAndFriend_Id(userId, friendUserId)) {
+            throw new GlobalException(FriendErrorCode.FRIEND_NOT_FOUND);
+        }
+        friendshipRepository.deleteByUser_IdAndFriend_Id(userId, friendUserId);
+        friendshipRepository.deleteByUser_IdAndFriend_Id(friendUserId, userId);
+    }
+
     @Transactional(readOnly = true)
     public List<FriendListRes> getFriendsByUserId(Long userId) {
         List<User> friends = friendshipRepository.findFriendsByUserId(userId);

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -41,6 +41,7 @@ import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 class FriendServiceTest {
@@ -558,7 +559,8 @@ class FriendServiceTest {
         // when
         friendService.deleteFriend(1L, 2L);
 
-        // then (예외 없이 정상 완료)
+        // then
+        verify(friendshipRepository).deleteFriendshipBidirectional(1L, 2L);
     }
 
     @Test

--- a/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/friend/service/FriendServiceTest.java
@@ -550,6 +550,31 @@ class FriendServiceTest {
     }
 
     @Test
+    @DisplayName("친구 삭제 정상 처리 - 양방향 Friendship 삭제")
+    void deleteFriend_success() {
+        // given
+        given(friendshipRepository.existsByUser_IdAndFriend_Id(1L, 2L)).willReturn(true);
+
+        // when
+        friendService.deleteFriend(1L, 2L);
+
+        // then (예외 없이 정상 완료)
+    }
+
+    @Test
+    @DisplayName("친구 관계가 없으면 FRIEND_NOT_FOUND 예외 발생")
+    void deleteFriend_notFound() {
+        // given
+        given(friendshipRepository.existsByUser_IdAndFriend_Id(1L, 2L)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> friendService.deleteFriend(1L, 2L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(FriendErrorCode.FRIEND_NOT_FOUND));
+    }
+
+    @Test
     @DisplayName("이미 처리된 친구 요청 거절 시 FRIEND_REQUEST_ALREADY_PROCESSED 예외 발생")
     void rejectFriendRequest_alreadyProcessed() {
         // given


### PR DESCRIPTION
 ## Related Issue
  - Close #56

## Task
  - `FriendErrorCode`에 `FRIEND_NOT_FOUND (6006, NOT_FOUND)` 추가
  - `FriendshipRepository`에 `deleteFriendshipBidirectional` 추가 (`@Modifying
  @Query` OR 조건 단일 DELETE)
  - `FriendService.deleteFriend()` 구현
    - `existsByUser_IdAndFriend_Id`로 친구 관계 확인 → 없으면 `FRIEND_NOT_FOUND`
  예외
    - `deleteFriendshipBidirectional`로 양방향 Friendship 단일 쿼리 삭제
  - `DELETE /api/friends/{friendUserId}` 엔드포인트 추가
  - `deleteFriend_success` (verify 포함), `deleteFriend_notFound` 테스트 추가

## To Reviewer
  - **단방향 존재 확인으로 충분한 이유**: 수락 API에서 `(userId→friendId)`,
  `(friendId→userId)` 양방향 INSERT가 보장되므로
  `existsByUser_IdAndFriend_Id(userId, friendUserId)` 단방향 체크만으로 친구 관계
  존재 여부 확인 가능
  - **`@Modifying @Query` 단일 DELETE 채택**: 파생
  delete(`deleteByUser_IdAndFriend_Id`) 두 번 호출 시 내부적으로 SELECT+DELETE × 2
   = 4쿼리 발생. `@Modifying @Query`로 OR 조건 단일 DELETE → 1쿼리로 처리
  - **`@Transactional` 범위**: `deleteFriendshipBidirectional` 호출이 하나의
  트랜잭션 내에서 실행되어 부분 삭제 방지
  - **`verify()` 추가**: `void` 반환 메서드는 예외 미발생만으로는 삭제 호출 보장
  불가 → `verify(friendshipRepository).deleteFriendshipBidirectional(1L, 2L)`로
  실제 호출 여부 검증

## Check List
  - [ ] PR 제목 규칙 준수
  - [ ] 라벨과 리뷰어 설정
  - [ ] 민감파일(*.yml 등) .gitignore 설정

<img width="949" height="819" alt="image" src="https://github.com/user-attachments/assets/b4767dec-599c-4ce5-bcc3-d0b5aab9e872" />
<img width="951" height="254" alt="image" src="https://github.com/user-attachments/assets/6446b2cc-4322-4223-9722-3e83d1aed95b" />
