### PR TITLE
[Fix] WebSocket subscriptionId null 체크 추가

### DIFF
--- a/src/main/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptor.java
@@ -98,12 +98,18 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
                 }
 
                 // 구독 시 검증한 참가 정보를 세션에 캐싱 → 발행 시 DB 재조회 없이 활용
-                artRunSubscriptions(accessor).put(accessor.getSubscriptionId(), sessionId);
+                String subscriptionId = accessor.getSubscriptionId();
+                if (subscriptionId != null) {
+                    artRunSubscriptions(accessor).put(subscriptionId, sessionId);
+                }
             }
         }
 
         if (StompCommand.UNSUBSCRIBE.equals(accessor.getCommand())) {
-            artRunSubscriptions(accessor).remove(accessor.getSubscriptionId());
+            String subscriptionId = accessor.getSubscriptionId();
+            if (subscriptionId != null) {
+                artRunSubscriptions(accessor).remove(subscriptionId);
+            }
         }
 
         return message;

--- a/src/main/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptor.java
+++ b/src/main/java/com/_s3k/runsync/global/websocket/interceptor/WebSocketAuthInterceptor.java
@@ -99,17 +99,19 @@ public class WebSocketAuthInterceptor implements ChannelInterceptor {
 
                 // 구독 시 검증한 참가 정보를 세션에 캐싱 → 발행 시 DB 재조회 없이 활용
                 String subscriptionId = accessor.getSubscriptionId();
-                if (subscriptionId != null) {
-                    artRunSubscriptions(accessor).put(subscriptionId, sessionId);
+                if (subscriptionId == null) {
+                    throw new IllegalArgumentException("구독 ID(subscriptionId)가 누락되었습니다.");
                 }
+                artRunSubscriptions(accessor).put(subscriptionId, sessionId);
             }
         }
 
         if (StompCommand.UNSUBSCRIBE.equals(accessor.getCommand())) {
             String subscriptionId = accessor.getSubscriptionId();
-            if (subscriptionId != null) {
-                artRunSubscriptions(accessor).remove(subscriptionId);
+            if (subscriptionId == null) {
+                throw new IllegalArgumentException("구독 ID(subscriptionId)가 누락되었습니다.");
             }
+            artRunSubscriptions(accessor).remove(subscriptionId);
         }
 
         return message;


### PR DESCRIPTION
## 📝작업 내용

WebSocket STOMP의 SUBSCRIBE / UNSUBSCRIBE 처리에서 subscriptionId가 null일 때 NPE가 날 수 있는 부분에 null 가드를 추가했습니다.
