### PR TITLE
[Feat] 닉네임 기반 사용자 검색 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendRequestRepository.java
@@ -4,6 +4,8 @@ import com._s3k.runsync.entity.FriendRequest;
 import com._s3k.runsync.entity.enums.FriendRequestStatus;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 import java.util.Optional;
@@ -22,4 +24,16 @@ public interface FriendRequestRepository extends JpaRepository<FriendRequest, Lo
 
     @EntityGraph(attributePaths = {"receiver"})
     List<FriendRequest> findBySender_IdAndStatusOrderByCreatedAtDesc(Long senderId, FriendRequestStatus status);
+
+    @Query("SELECT fr.receiver.id FROM FriendRequest fr " +
+            "WHERE fr.sender.id = :userId AND fr.receiver.id IN :targetIds AND fr.status = :status")
+    List<Long> findReceiverIdsBySenderAndStatus(@Param("userId") Long userId,
+                                                @Param("targetIds") List<Long> targetIds,
+                                                @Param("status") FriendRequestStatus status);
+
+    @Query("SELECT fr.sender.id FROM FriendRequest fr " +
+            "WHERE fr.receiver.id = :userId AND fr.sender.id IN :targetIds AND fr.status = :status")
+    List<Long> findSenderIdsByReceiverAndStatus(@Param("userId") Long userId,
+                                                @Param("targetIds") List<Long> targetIds,
+                                                @Param("status") FriendRequestStatus status);
 }

--- a/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendshipRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/friend/repository/FriendshipRepository.java
@@ -16,6 +16,9 @@ public interface FriendshipRepository extends JpaRepository<Friendship, Long> {
 
     boolean existsByUser_IdAndFriend_Id(Long userId, Long friendId);
 
+    @Query("SELECT f.friend.id FROM Friendship f WHERE f.user.id = :userId AND f.friend.id IN :targetIds")
+    List<Long> findFriendIdsByUserIdAndFriendIdIn(@Param("userId") Long userId, @Param("targetIds") List<Long> targetIds);
+
     @Modifying
     @Query("DELETE FROM Friendship f WHERE (f.user.id = :userId AND f.friend.id = :friendId) OR (f.user.id = :friendId AND f.friend.id = :userId)")
     void deleteFriendshipBidirectional(@Param("userId") Long userId, @Param("friendId") Long friendId);

--- a/src/main/java/com/_s3k/runsync/domain/users/controller/UserController.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/controller/UserController.java
@@ -8,7 +8,11 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -18,6 +22,7 @@ import com._s3k.runsync.domain.users.dto.request.UserUpdateReq;
 import com._s3k.runsync.domain.users.dto.response.UserInfoRes;
 import com._s3k.runsync.domain.users.dto.response.UserProfileRes;
 import com._s3k.runsync.domain.users.dto.response.UserRecordsScrollRes;
+import com._s3k.runsync.domain.users.dto.response.UserSearchScrollRes;
 import com._s3k.runsync.domain.users.dto.response.UserSummaryRes;
 import com._s3k.runsync.domain.users.dto.response.UserUpdateRes;
 import com._s3k.runsync.global.common.dto.CommonResponse;
@@ -26,6 +31,7 @@ import com._s3k.runsync.global.common.dto.CommonResponse;
 @RestController
 @RequestMapping("/api/users")
 @RequiredArgsConstructor
+@Validated
 public class UserController {
 
     private final UserService userService;
@@ -47,6 +53,21 @@ public class UserController {
             @PathVariable("userId") Long targetUserId
     ) {
         return CommonResponse.success(userService.getUserById(targetUserId));
+    }
+
+    @Operation(summary = "닉네임 사용자 검색", description = "닉네임 부분 일치로 사용자 검색 (본인 제외, 커서 페이지네이션): 로그인 필요")
+    @GetMapping("/search")
+    public CommonResponse<UserSearchScrollRes> searchUsers(
+            @Parameter(description = "사용자 ID", required = true)
+            @AuthenticationPrincipal Long userId,
+            @Parameter(description = "검색할 닉네임", required = true)
+            @RequestParam @NotBlank String nickname,
+            @Parameter(description = "마지막으로 받은 userId (첫 요청 시 생략)")
+            @RequestParam(required = false) Long cursor,
+            @Parameter(description = "조회할 사용자 수 (기본값 10, 1~100)")
+            @RequestParam(defaultValue = "10") @Min(1) @Max(100) int size
+    ) {
+        return CommonResponse.success(userService.searchUsersByNickname(userId, nickname, cursor, size));
     }
 
     @Operation(summary = "내 정보 수정", description = "내 정보 수정: 로그인 필요")

--- a/src/main/java/com/_s3k/runsync/domain/users/dto/response/UserSearchRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/dto/response/UserSearchRes.java
@@ -1,0 +1,34 @@
+package com._s3k.runsync.domain.users.dto.response;
+
+import com._s3k.runsync.entity.User;
+import com._s3k.runsync.entity.enums.UserRelation;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "사용자 검색 결과")
+public class UserSearchRes {
+
+    @Schema(description = "사용자 ID", example = "10")
+    private Long id;
+
+    @Schema(description = "닉네임", example = "hw0o")
+    private String nickname;
+
+    @Schema(description = "프로필 이미지 URL", example = "https://sample.com/profile.png")
+    private String profileImage;
+
+    @Schema(description = "나와의 관계 (NONE / FRIEND / REQUEST_SENT / REQUEST_RECEIVED)", example = "NONE")
+    private UserRelation relation;
+
+    private UserSearchRes(Long id, String nickname, String profileImage, UserRelation relation) {
+        this.id = id;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+        this.relation = relation;
+    }
+
+    public static UserSearchRes of(User user, UserRelation relation) {
+        return new UserSearchRes(user.getId(), user.getNickname(), user.getProfileImage(), relation);
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/users/dto/response/UserSearchScrollRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/dto/response/UserSearchScrollRes.java
@@ -1,0 +1,33 @@
+package com._s3k.runsync.domain.users.dto.response;
+
+import com._s3k.runsync.global.common.ScrollPaginationCollection;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Schema(description = "사용자 검색 목록 응답")
+public class UserSearchScrollRes {
+
+    @Schema(description = "다음 페이지 존재 여부", example = "false")
+    private boolean hasNext;
+
+    @Schema(description = "다음 요청에 사용할 커서 (마지막 userId)", example = "10")
+    private Long nextCursor;
+
+    @Schema(description = "검색된 사용자 목록")
+    private List<UserSearchRes> users;
+
+    private UserSearchScrollRes(boolean hasNext, Long nextCursor, List<UserSearchRes> users) {
+        this.hasNext = hasNext;
+        this.nextCursor = nextCursor;
+        this.users = users;
+    }
+
+    public static UserSearchScrollRes of(ScrollPaginationCollection<UserSearchRes> collection) {
+        List<UserSearchRes> contents = collection.getCurrentPageContents();
+        Long nextCursor = collection.hasNext() ? contents.get(contents.size() - 1).getId() : null;
+        return new UserSearchScrollRes(collection.hasNext(), nextCursor, contents);
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/users/repository/UserRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/repository/UserRepository.java
@@ -1,8 +1,12 @@
 package com._s3k.runsync.domain.users.repository;
 
+import java.util.List;
 import java.util.Optional;
 
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import com._s3k.runsync.entity.User;
 
@@ -10,4 +14,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	Optional<User> findByProviderId(String providerId);
 
 	boolean existsByNicknameAndIdNot(String nickname, Long id);
+
+	@Query("SELECT u FROM User u WHERE u.id <> :userId AND u.isDeleted = false " +
+			"AND LOWER(u.nickname) LIKE LOWER(CONCAT('%', :nickname, '%')) " +
+			"AND (:cursor IS NULL OR u.id > :cursor) ORDER BY u.id ASC")
+	List<User> searchByNickname(@Param("userId") Long userId, @Param("nickname") String nickname,
+								@Param("cursor") Long cursor, Pageable pageable);
 }

--- a/src/main/java/com/_s3k/runsync/domain/users/repository/UserRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/repository/UserRepository.java
@@ -16,7 +16,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 	boolean existsByNicknameAndIdNot(String nickname, Long id);
 
 	@Query("SELECT u FROM User u WHERE u.id <> :userId AND u.isDeleted = false " +
-			"AND LOWER(u.nickname) LIKE LOWER(CONCAT('%', :nickname, '%')) " +
+			"AND LOWER(u.nickname) LIKE LOWER(CONCAT('%', :nickname, '%')) ESCAPE '\\' " +
 			"AND (:cursor IS NULL OR u.id > :cursor) ORDER BY u.id ASC")
 	List<User> searchByNickname(@Param("userId") Long userId, @Param("nickname") String nickname,
 								@Param("cursor") Long cursor, Pageable pageable);

--- a/src/main/java/com/_s3k/runsync/domain/users/service/UserService.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/service/UserService.java
@@ -113,7 +113,8 @@ public class UserService {
 
     @Transactional(readOnly = true)
     public UserSearchScrollRes searchUsersByNickname(Long userId, String nickname, Long cursor, int size) {
-        List<User> users = userRepository.searchByNickname(userId, nickname, cursor, PageRequest.of(0, size + 1));
+        String escapedNickname = nickname.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_");
+        List<User> users = userRepository.searchByNickname(userId, escapedNickname, cursor, PageRequest.of(0, size + 1));
         if (users.isEmpty()) {
             return UserSearchScrollRes.of(ScrollPaginationCollection.of(List.of(), size));
         }

--- a/src/main/java/com/_s3k/runsync/domain/users/service/UserService.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/service/UserService.java
@@ -7,16 +7,22 @@ import org.springframework.transaction.annotation.Transactional;
 import lombok.RequiredArgsConstructor;
 import com._s3k.runsync.entity.RunRecord;
 import com._s3k.runsync.entity.User;
+import com._s3k.runsync.domain.friend.repository.FriendRequestRepository;
+import com._s3k.runsync.domain.friend.repository.FriendshipRepository;
 import com._s3k.runsync.domain.run.repository.MonthlyStatsProjection;
 import com._s3k.runsync.domain.run.repository.RunRecordRepository;
 import com._s3k.runsync.domain.users.repository.UserRepository;
 import com._s3k.runsync.domain.users.exception.UserErrorCode;
+import com._s3k.runsync.entity.enums.FriendRequestStatus;
 import com._s3k.runsync.entity.enums.Role;
+import com._s3k.runsync.entity.enums.UserRelation;
 import com._s3k.runsync.domain.users.dto.request.UserUpdateReq;
 import com._s3k.runsync.domain.users.dto.response.RecordRes;
 import com._s3k.runsync.domain.users.dto.response.UserInfoRes;
 import com._s3k.runsync.domain.users.dto.response.UserProfileRes;
 import com._s3k.runsync.domain.users.dto.response.UserRecordsScrollRes;
+import com._s3k.runsync.domain.users.dto.response.UserSearchRes;
+import com._s3k.runsync.domain.users.dto.response.UserSearchScrollRes;
 import com._s3k.runsync.domain.users.dto.response.UserSummaryRes;
 import com._s3k.runsync.domain.users.dto.response.UserUpdateRes;
 import com._s3k.runsync.global.common.ScrollPaginationCollection;
@@ -24,7 +30,9 @@ import com._s3k.runsync.global.exception.GlobalException;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -33,6 +41,8 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final RunRecordRepository runRecordRepository;
+    private final FriendshipRepository friendshipRepository;
+    private final FriendRequestRepository friendRequestRepository;
     private final Clock clock;
 
     @Transactional(readOnly = true)
@@ -99,5 +109,37 @@ public class UserService {
                 .collect(Collectors.toList());
 
         return UserRecordsScrollRes.of(ScrollPaginationCollection.of(recordResList, size));
+    }
+
+    @Transactional(readOnly = true)
+    public UserSearchScrollRes searchUsersByNickname(Long userId, String nickname, Long cursor, int size) {
+        List<User> users = userRepository.searchByNickname(userId, nickname, cursor, PageRequest.of(0, size + 1));
+        if (users.isEmpty()) {
+            return UserSearchScrollRes.of(ScrollPaginationCollection.of(List.of(), size));
+        }
+
+        List<Long> targetIds = users.stream().map(User::getId).toList();
+        Set<Long> friendIds = new HashSet<>(friendshipRepository.findFriendIdsByUserIdAndFriendIdIn(userId, targetIds));
+        Set<Long> sentIds = new HashSet<>(friendRequestRepository.findReceiverIdsBySenderAndStatus(userId, targetIds, FriendRequestStatus.PENDING));
+        Set<Long> receivedIds = new HashSet<>(friendRequestRepository.findSenderIdsByReceiverAndStatus(userId, targetIds, FriendRequestStatus.PENDING));
+
+        List<UserSearchRes> searchResList = users.stream()
+                .map(user -> UserSearchRes.of(user, resolveRelation(user.getId(), friendIds, sentIds, receivedIds)))
+                .collect(Collectors.toList());
+
+        return UserSearchScrollRes.of(ScrollPaginationCollection.of(searchResList, size));
+    }
+
+    private UserRelation resolveRelation(Long targetId, Set<Long> friendIds, Set<Long> sentIds, Set<Long> receivedIds) {
+        if (friendIds.contains(targetId)) {
+            return UserRelation.FRIEND;
+        }
+        if (sentIds.contains(targetId)) {
+            return UserRelation.REQUEST_SENT;
+        }
+        if (receivedIds.contains(targetId)) {
+            return UserRelation.REQUEST_RECEIVED;
+        }
+        return UserRelation.NONE;
     }
 }

--- a/src/main/java/com/_s3k/runsync/entity/enums/UserRelation.java
+++ b/src/main/java/com/_s3k/runsync/entity/enums/UserRelation.java
@@ -1,0 +1,8 @@
+package com._s3k.runsync.entity.enums;
+
+public enum UserRelation {
+    NONE,
+    FRIEND,
+    REQUEST_SENT,
+    REQUEST_RECEIVED
+}

--- a/src/test/java/com/_s3k/runsync/domain/users/service/UserServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/users/service/UserServiceTest.java
@@ -1,0 +1,129 @@
+package com._s3k.runsync.domain.users.service;
+
+import com._s3k.runsync.domain.friend.repository.FriendRequestRepository;
+import com._s3k.runsync.domain.friend.repository.FriendshipRepository;
+import com._s3k.runsync.domain.run.repository.RunRecordRepository;
+import com._s3k.runsync.domain.users.dto.response.UserSearchScrollRes;
+import com._s3k.runsync.domain.users.repository.UserRepository;
+import com._s3k.runsync.entity.User;
+import com._s3k.runsync.entity.enums.FriendRequestStatus;
+import com._s3k.runsync.entity.enums.Provider;
+import com._s3k.runsync.entity.enums.UserRelation;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Clock;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @InjectMocks
+    private UserService userService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private RunRecordRepository runRecordRepository;
+
+    @Mock
+    private FriendshipRepository friendshipRepository;
+
+    @Mock
+    private FriendRequestRepository friendRequestRepository;
+
+    @Mock
+    private Clock clock;
+
+    @Test
+    @DisplayName("닉네임 검색 성공 - 친구/보낸요청/받은요청/없음 관계가 정확히 매핑된다")
+    void searchUsersByNickname_relationMapping() {
+        // given
+        Long me = 1L;
+        User friend = user(10L, "hw_friend");
+        User sent = user(11L, "hw_sent");
+        User received = user(12L, "hw_received");
+        User none = user(13L, "hw_none");
+
+        given(userRepository.searchByNickname(eq(me), eq("hw"), any(), any(Pageable.class)))
+                .willReturn(List.of(friend, sent, received, none));
+        given(friendshipRepository.findFriendIdsByUserIdAndFriendIdIn(eq(me), anyList()))
+                .willReturn(List.of(10L));
+        given(friendRequestRepository.findReceiverIdsBySenderAndStatus(eq(me), anyList(), eq(FriendRequestStatus.PENDING)))
+                .willReturn(List.of(11L));
+        given(friendRequestRepository.findSenderIdsByReceiverAndStatus(eq(me), anyList(), eq(FriendRequestStatus.PENDING)))
+                .willReturn(List.of(12L));
+
+        // when
+        UserSearchScrollRes result = userService.searchUsersByNickname(me, "hw", null, 10);
+
+        // then
+        assertThat(result.getUsers()).hasSize(4);
+        assertThat(result.isHasNext()).isFalse();
+        assertThat(result.getNextCursor()).isNull();
+        assertThat(result.getUsers().get(0).getRelation()).isEqualTo(UserRelation.FRIEND);
+        assertThat(result.getUsers().get(1).getRelation()).isEqualTo(UserRelation.REQUEST_SENT);
+        assertThat(result.getUsers().get(2).getRelation()).isEqualTo(UserRelation.REQUEST_RECEIVED);
+        assertThat(result.getUsers().get(3).getRelation()).isEqualTo(UserRelation.NONE);
+    }
+
+    @Test
+    @DisplayName("닉네임 검색 결과 없음 - 빈 목록 반환, 관계 조회를 호출하지 않는다")
+    void searchUsersByNickname_empty() {
+        // given
+        given(userRepository.searchByNickname(any(), any(), any(), any(Pageable.class)))
+                .willReturn(List.of());
+
+        // when
+        UserSearchScrollRes result = userService.searchUsersByNickname(1L, "nobody", null, 10);
+
+        // then
+        assertThat(result.getUsers()).isEmpty();
+        assertThat(result.isHasNext()).isFalse();
+        assertThat(result.getNextCursor()).isNull();
+        verify(friendshipRepository, never()).findFriendIdsByUserIdAndFriendIdIn(any(), anyList());
+    }
+
+    @Test
+    @DisplayName("닉네임 검색 다음 페이지 존재 - size+1건 조회 시 hasNext=true, nextCursor=현재 페이지 마지막 id")
+    void searchUsersByNickname_hasNext() {
+        // given size=2 인데 3건(size+1) 반환
+        Long me = 1L;
+        given(userRepository.searchByNickname(eq(me), eq("hw"), any(), any(Pageable.class)))
+                .willReturn(List.of(user(1L, "hw1"), user(2L, "hw2"), user(3L, "hw3")));
+        given(friendshipRepository.findFriendIdsByUserIdAndFriendIdIn(eq(me), anyList())).willReturn(List.of());
+        given(friendRequestRepository.findReceiverIdsBySenderAndStatus(eq(me), anyList(), any())).willReturn(List.of());
+        given(friendRequestRepository.findSenderIdsByReceiverAndStatus(eq(me), anyList(), any())).willReturn(List.of());
+
+        // when
+        UserSearchScrollRes result = userService.searchUsersByNickname(me, "hw", null, 2);
+
+        // then
+        assertThat(result.getUsers()).hasSize(2);
+        assertThat(result.isHasNext()).isTrue();
+        assertThat(result.getNextCursor()).isEqualTo(2L);
+        assertThat(result.getUsers().get(0).getId()).isEqualTo(1L);
+        assertThat(result.getUsers().get(1).getId()).isEqualTo(2L);
+    }
+
+    private User user(Long id, String nickname) {
+        User user = User.createTmpUser(Provider.KAKAO, "kakao" + id, nickname, "img" + id);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}


### PR DESCRIPTION
## #️⃣연관된 이슈

> #63 

## 📝작업 내용
닉네임으로 사용자를 검색하는 API를 추가했습니다. (친구 추가: 검색 → 요청 흐름의 선행 API)
- 닉네임 **부분 일치**(대소문자 무시), **본인·탈퇴자 제외**
- **커서 기반 페이지네이션** (기존 방식과 동일)
- 각 결과에 **나와의 관계(relation)** 포함 → FE가 "친구 요청/요청됨/이미친구" 버튼 상태 표시용
- `NONE` / `FRIEND` / `REQUEST_SENT`(내가 보냄) / `REQUEST_RECEIVED`(상대가 보냄)
- 관계 조회는 **배치 쿼리**로 처리해 N+1 방지

## 📷스크린샷 
<img width="1446" height="586" alt="스크린샷 2026-06-08 오후 3 44 24" src="https://github.com/user-attachments/assets/eef9c289-e6f1-422f-b165-c554051f70f9" />
<img width="1436" height="667" alt="스크린샷 2026-06-08 오후 3 44 32" src="https://github.com/user-attachments/assets/e0f7ecd1-9888-4c13-ad18-cc5ff83b5cfb" />
