### PR TITLE
[Feat] 협동 러닝-개인 러닝 세션 링크 추가

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/artrun/exception/ArtRunErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/exception/ArtRunErrorCode.java
@@ -16,7 +16,8 @@ public enum ArtRunErrorCode implements ResultCode {
     NOT_PARTICIPANT(HttpStatus.NOT_FOUND, 5005, "참가 중인 세션이 아닙니다."),
     HOST_CANNOT_LEAVE(HttpStatus.CONFLICT, 5006, "호스트는 참가를 취소할 수 없습니다."),
     NOT_HOST(HttpStatus.FORBIDDEN, 5007, "호스트만 가능한 작업입니다."),
-    INVALID_STATUS_TRANSITION(HttpStatus.CONFLICT, 5008, "잘못된 상태 변경입니다.");
+    INVALID_STATUS_TRANSITION(HttpStatus.CONFLICT, 5008, "잘못된 상태 변경입니다."),
+    ARTRUN_NOT_IN_PROGRESS(HttpStatus.CONFLICT, 5009, "진행 중인 협동 러닝이 아닙니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunSessionStartReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunSessionStartReq.java
@@ -3,6 +3,7 @@ package com._s3k.runsync.domain.run.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.PastOrPresent;
+import jakarta.validation.constraints.Positive;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -18,6 +19,7 @@ public class RunSessionStartReq {
     @Schema(description = "러닝 시작 시간", example = "2026-04-10T22:11:00")
     private LocalDateTime startTime;
 
+    @Positive
     @Schema(description = "협동 러닝 세션 ID (협동 러닝 참가 시에만 전송, 일반 러닝은 생략)", example = "100")
     private Long artRunSessionId;
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunSessionStartReq.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/request/RunSessionStartReq.java
@@ -17,4 +17,7 @@ public class RunSessionStartReq {
     @PastOrPresent
     @Schema(description = "러닝 시작 시간", example = "2026-04-10T22:11:00")
     private LocalDateTime startTime;
+
+    @Schema(description = "협동 러닝 세션 ID (협동 러닝 참가 시에만 전송, 일반 러닝은 생략)", example = "100")
+    private Long artRunSessionId;
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
@@ -1,5 +1,7 @@
 package com._s3k.runsync.domain.run.service;
 
+import com._s3k.runsync.domain.artrun.exception.ArtRunErrorCode;
+import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
 import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.domain.run.dto.request.LocationUpdateReq;
 import com._s3k.runsync.domain.run.dto.request.RunRecordDetailReq;
@@ -47,6 +49,7 @@ public class RunSessionService {
     private final RunRecordRepository runRecordRepository;
     private final RunSessionRedisRepository runSessionRedisRepository;
     private final LocationService locationService;
+    private final ArtRunParticipantRepository artRunParticipantRepository;
     private final ObjectMapper objectMapper;
 
 
@@ -60,8 +63,14 @@ public class RunSessionService {
             throw new GlobalException(RunSessionErrorCode.ACTIVE_SESSION_ALREADY_EXISTS);
         }
 
+        Long artRunSessionId = request.getArtRunSessionId();
+        if (artRunSessionId != null
+                && !artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(artRunSessionId, userId)) {
+            throw new GlobalException(ArtRunErrorCode.NOT_PARTICIPANT);
+        }
+
         try {
-            RunningSession session = RunningSession.of(user, request.getStartTime());
+            RunningSession session = RunningSession.of(user, request.getStartTime(), artRunSessionId);
             runningSessionRepository.save(session);
             return RunSessionStartRes.of(session);
         } catch (DataIntegrityViolationException e) {

--- a/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
@@ -2,6 +2,7 @@ package com._s3k.runsync.domain.run.service;
 
 import com._s3k.runsync.domain.artrun.exception.ArtRunErrorCode;
 import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
+import com._s3k.runsync.domain.artrun.repository.ArtRunSessionRepository;
 import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.domain.run.dto.request.LocationUpdateReq;
 import com._s3k.runsync.domain.run.dto.request.RunRecordDetailReq;
@@ -16,6 +17,7 @@ import com._s3k.runsync.domain.run.repository.RunSessionRedisRepository;
 import com._s3k.runsync.domain.run.repository.RunningSessionRepository;
 import com._s3k.runsync.domain.users.exception.UserErrorCode;
 import com._s3k.runsync.domain.users.repository.UserRepository;
+import com._s3k.runsync.entity.ArtRunSession;
 import com._s3k.runsync.entity.RunPath;
 import com._s3k.runsync.entity.RunRecord;
 import com._s3k.runsync.entity.RunningSession;
@@ -50,6 +52,7 @@ public class RunSessionService {
     private final RunSessionRedisRepository runSessionRedisRepository;
     private final LocationService locationService;
     private final ArtRunParticipantRepository artRunParticipantRepository;
+    private final ArtRunSessionRepository artRunSessionRepository;
     private final ObjectMapper objectMapper;
 
 
@@ -64,9 +67,13 @@ public class RunSessionService {
         }
 
         Long artRunSessionId = request.getArtRunSessionId();
-        if (artRunSessionId != null
-                && !artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(artRunSessionId, userId)) {
-            throw new GlobalException(ArtRunErrorCode.NOT_PARTICIPANT);
+        if (artRunSessionId != null) {
+            ArtRunSession artRunSession = artRunSessionRepository.findById(artRunSessionId)
+                    .orElseThrow(() -> new GlobalException(ArtRunErrorCode.SESSION_NOT_FOUND));
+            if (!artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(artRunSessionId, userId)) {
+                throw new GlobalException(ArtRunErrorCode.NOT_PARTICIPANT);
+            }
+            artRunSession.validateInProgress();
         }
 
         try {

--- a/src/main/java/com/_s3k/runsync/entity/ArtRunSession.java
+++ b/src/main/java/com/_s3k/runsync/entity/ArtRunSession.java
@@ -102,4 +102,10 @@ public class ArtRunSession extends BaseEntity {
             throw new GlobalException(ArtRunErrorCode.NOT_HOST);
         }
     }
+
+    public void validateInProgress() {
+        if (this.status != ArtRunStatus.IN_PROGRESS) {
+            throw new GlobalException(ArtRunErrorCode.ARTRUN_NOT_IN_PROGRESS);
+        }
+    }
 }

--- a/src/main/java/com/_s3k/runsync/entity/RunningSession.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunningSession.java
@@ -48,21 +48,30 @@ public class RunningSession extends BaseEntity {
     @Column(name = "current_duration_time")
     private Integer currentDurationTime;
 
+    @Column(name = "art_run_session_id")
+    private Long artRunSessionId;
+
     @Column(name = "user_id", insertable = false, updatable = false)
     private Long userId;
 
     @Builder(access = AccessLevel.PRIVATE)
-    private RunningSession(User user, LocalDateTime startTime) {
+    private RunningSession(User user, LocalDateTime startTime, Long artRunSessionId) {
         this.user = user;
         this.startTime = startTime;
         this.status = RunningSessionStatus.ACTIVE;
         this.totalDistance = BigDecimal.ZERO;
+        this.artRunSessionId = artRunSessionId;
     }
 
     public static RunningSession of(User user, LocalDateTime startTime) {
+        return of(user, startTime, null);
+    }
+
+    public static RunningSession of(User user, LocalDateTime startTime, Long artRunSessionId) {
         return RunningSession.builder()
                 .user(user)
                 .startTime(startTime)
+                .artRunSessionId(artRunSessionId)
                 .build();
     }
 

--- a/src/main/java/com/_s3k/runsync/entity/RunningSession.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunningSession.java
@@ -18,7 +18,8 @@ import java.time.LocalDateTime;
 import java.util.Objects;
 
 @Entity
-@Table(name = "running_session")
+@Table(name = "running_session",
+        indexes = @Index(name = "idx_running_session_art_run_session_id", columnList = "art_run_session_id"))
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class RunningSession extends BaseEntity {

--- a/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
@@ -1,5 +1,7 @@
 package com._s3k.runsync.domain.run.service;
 
+import com._s3k.runsync.domain.artrun.exception.ArtRunErrorCode;
+import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
 import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.domain.run.dto.request.LocationUpdateReq;
 import com._s3k.runsync.domain.run.dto.request.RunRecordDetailReq;
@@ -21,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -61,6 +64,9 @@ class RunSessionServiceTest {
 
     @Mock
     private LocationService locationService;
+
+    @Mock
+    private ArtRunParticipantRepository artRunParticipantRepository;
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -121,6 +127,55 @@ class RunSessionServiceTest {
                 .isInstanceOf(GlobalException.class)
                 .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
                         .isEqualTo(RunSessionErrorCode.ACTIVE_SESSION_ALREADY_EXISTS));
+
+        verify(runningSessionRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("협동 러닝 참가자가 artRunSessionId를 보내면 링크가 저장된다")
+    void createRunSession_withArtRunSessionId_success() {
+        // given
+        Long userId = 1L;
+        Long artRunSessionId = 100L;
+        RunSessionStartReq request = new RunSessionStartReq();
+        ReflectionTestUtils.setField(request, "startTime", LocalDateTime.now());
+        ReflectionTestUtils.setField(request, "artRunSessionId", artRunSessionId);
+
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(false);
+        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(artRunSessionId, userId)).willReturn(true);
+        given(runningSessionRepository.save(any(RunningSession.class))).willAnswer(i -> i.getArgument(0));
+
+        // when
+        runSessionService.createRunSession(userId, request);
+
+        // then
+        ArgumentCaptor<RunningSession> captor = ArgumentCaptor.forClass(RunningSession.class);
+        verify(runningSessionRepository).save(captor.capture());
+        assertThat(captor.getValue().getArtRunSessionId()).isEqualTo(artRunSessionId);
+    }
+
+    @Test
+    @DisplayName("협동 러닝 비참가자가 artRunSessionId를 보내면 예외 발생")
+    void createRunSession_artRunNotParticipant() {
+        // given
+        Long userId = 1L;
+        Long artRunSessionId = 100L;
+        RunSessionStartReq request = new RunSessionStartReq();
+        ReflectionTestUtils.setField(request, "startTime", LocalDateTime.now());
+        ReflectionTestUtils.setField(request, "artRunSessionId", artRunSessionId);
+
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(false);
+        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(artRunSessionId, userId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.createRunSession(userId, request))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.NOT_PARTICIPANT));
 
         verify(runningSessionRepository, never()).save(any());
     }

--- a/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
@@ -2,6 +2,7 @@ package com._s3k.runsync.domain.run.service;
 
 import com._s3k.runsync.domain.artrun.exception.ArtRunErrorCode;
 import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
+import com._s3k.runsync.domain.artrun.repository.ArtRunSessionRepository;
 import com._s3k.runsync.domain.location.service.LocationService;
 import com._s3k.runsync.domain.run.dto.request.LocationUpdateReq;
 import com._s3k.runsync.domain.run.dto.request.RunRecordDetailReq;
@@ -13,6 +14,7 @@ import com._s3k.runsync.domain.run.repository.RunSessionRedisRepository;
 import com._s3k.runsync.domain.run.repository.RunningSessionRepository;
 import com._s3k.runsync.domain.users.exception.UserErrorCode;
 import com._s3k.runsync.domain.users.repository.UserRepository;
+import com._s3k.runsync.entity.ArtRunSession;
 import com._s3k.runsync.entity.RunRecord;
 import com._s3k.runsync.entity.RunningSession;
 import com._s3k.runsync.entity.User;
@@ -67,6 +69,9 @@ class RunSessionServiceTest {
 
     @Mock
     private ArtRunParticipantRepository artRunParticipantRepository;
+
+    @Mock
+    private ArtRunSessionRepository artRunSessionRepository;
 
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
@@ -142,8 +147,10 @@ class RunSessionServiceTest {
         ReflectionTestUtils.setField(request, "artRunSessionId", artRunSessionId);
 
         User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        ArtRunSession artRunSession = mock(ArtRunSession.class);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(false);
+        given(artRunSessionRepository.findById(artRunSessionId)).willReturn(Optional.of(artRunSession));
         given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(artRunSessionId, userId)).willReturn(true);
         given(runningSessionRepository.save(any(RunningSession.class))).willAnswer(i -> i.getArgument(0));
 
@@ -154,6 +161,7 @@ class RunSessionServiceTest {
         ArgumentCaptor<RunningSession> captor = ArgumentCaptor.forClass(RunningSession.class);
         verify(runningSessionRepository).save(captor.capture());
         assertThat(captor.getValue().getArtRunSessionId()).isEqualTo(artRunSessionId);
+        verify(artRunSession).validateInProgress();
     }
 
     @Test
@@ -169,6 +177,7 @@ class RunSessionServiceTest {
         User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(false);
+        given(artRunSessionRepository.findById(artRunSessionId)).willReturn(Optional.of(mock(ArtRunSession.class)));
         given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(artRunSessionId, userId)).willReturn(false);
 
         // when & then
@@ -176,6 +185,57 @@ class RunSessionServiceTest {
                 .isInstanceOf(GlobalException.class)
                 .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
                         .isEqualTo(ArtRunErrorCode.NOT_PARTICIPANT));
+
+        verify(runningSessionRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 협동 러닝 세션 ID를 보내면 예외 발생")
+    void createRunSession_artRunSessionNotFound() {
+        // given
+        Long userId = 1L;
+        Long artRunSessionId = 100L;
+        RunSessionStartReq request = new RunSessionStartReq();
+        ReflectionTestUtils.setField(request, "startTime", LocalDateTime.now());
+        ReflectionTestUtils.setField(request, "artRunSessionId", artRunSessionId);
+
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(false);
+        given(artRunSessionRepository.findById(artRunSessionId)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.createRunSession(userId, request))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.SESSION_NOT_FOUND));
+
+        verify(runningSessionRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("진행 중이 아닌 협동 러닝에 링크 시도 시 예외 발생")
+    void createRunSession_artRunNotInProgress() {
+        // given
+        Long userId = 1L;
+        Long artRunSessionId = 100L;
+        RunSessionStartReq request = new RunSessionStartReq();
+        ReflectionTestUtils.setField(request, "startTime", LocalDateTime.now());
+        ReflectionTestUtils.setField(request, "artRunSessionId", artRunSessionId);
+
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        ArtRunSession artRunSession = mock(ArtRunSession.class);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(false);
+        given(artRunSessionRepository.findById(artRunSessionId)).willReturn(Optional.of(artRunSession));
+        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(artRunSessionId, userId)).willReturn(true);
+        doThrow(new GlobalException(ArtRunErrorCode.ARTRUN_NOT_IN_PROGRESS)).when(artRunSession).validateInProgress();
+
+        // when & then
+        assertThatThrownBy(() -> runSessionService.createRunSession(userId, request))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.ARTRUN_NOT_IN_PROGRESS));
 
         verify(runningSessionRepository, never()).save(any());
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #65 

## 📝작업 내용

협동 러닝 결과 조회(#66)의 **선행 작업**으로, "어느 개인 러닝이 어느 협동 러닝의 것인지" 식별하기 위한 연결고리를 추가했습니다.

 협동 러닝 위치는 WebSocket pub/sub로만 흘러 저장되지 않고, 개인 RunningSession/RunRecord와 협동 러닝 간 연결고리가 없었습니다. 러닝 시작 시 FE가 `artRunSessionId`를 전달하면 RunningSession에 저장하는 방식(명시적 전달)으로 해결했습니다.

### 변경 사항
- `RunningSession`에 `art_run_session_id` 컬럼 추가 (nullable, 순수 Long 컬럼)
- `RunSessionStartReq`에 `artRunSessionId`(선택) 추가 — 협동 러닝 참가 시에만 전송, 일반 러닝은 생략
- `createRunSession`: `artRunSessionId`가 있으면 **참가자 검증**(ArtRunParticipant 존재) 후 저장, 비참가자면 `NOT_PARTICIPANT`로 거부

### API 변경
`POST /api/run-sessions` body에 `artRunSessionId`(nullable) 추가
- 일반 개인 러닝: 미전송(null) → 기존과 동일하게 동작
- 협동 러닝 run: 해당 세션 ID 전송 → 검증 후 링크 저장

