### PR TITLE
[Feat] 협동 러닝 결과 조회 API 구현

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/artrun/controller/ArtRunController.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/controller/ArtRunController.java
@@ -4,6 +4,7 @@ import com._s3k.runsync.domain.artrun.dto.request.ArtRunCreateReq;
 import com._s3k.runsync.domain.artrun.dto.request.ArtRunStatusUpdateReq;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunCreateRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunDetailRes;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunResultRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunScrollRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunStatusRes;
 import com._s3k.runsync.domain.artrun.service.ArtRunService;
@@ -59,6 +60,15 @@ public class ArtRunController {
             @PathVariable Long sessionId
     ) {
         return CommonResponse.success(artRunService.getArtRunById(sessionId));
+    }
+
+    @GetMapping("/{sessionId}/result")
+    @Operation(summary = "협동 러닝 결과 조회", description = "종료된 협동 러닝의 참가자별 기록(경로/거리/시간)과 도안을 조회합니다. 참가자/호스트만 가능. 로그인 필요")
+    public CommonResponse<ArtRunResultRes> getArtRunResult(
+            @AuthenticationPrincipal Long userId,
+            @PathVariable Long sessionId
+    ) {
+        return CommonResponse.success(artRunService.getArtRunResultBySessionId(userId, sessionId));
     }
 
     @PostMapping("/{sessionId}/participants")

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunResultParticipantRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunResultParticipantRes.java
@@ -1,0 +1,57 @@
+package com._s3k.runsync.domain.artrun.dto.response;
+
+import com._s3k.runsync.domain.run.dto.response.RunPathRes;
+import com._s3k.runsync.entity.ArtRunParticipant;
+import com._s3k.runsync.entity.RunRecord;
+import com._s3k.runsync.entity.User;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Schema(description = "협동 러닝 결과 - 참가자별 기록")
+public class ArtRunResultParticipantRes {
+
+    @Schema(description = "참가자 사용자 ID", example = "10")
+    private final Long userId;
+
+    @Schema(description = "닉네임", example = "현우")
+    private final String nickname;
+
+    @Schema(description = "프로필 이미지", example = "https://sample.com/1.png")
+    private final String profileImage;
+
+    @Schema(description = "뛴 거리(km)", example = "2.59")
+    private final Double distance;
+
+    @Schema(description = "소요 시간(초)", example = "1048")
+    private final Integer durationSeconds;
+
+    @Schema(description = "실제 뛴 GPS 경로")
+    private final List<RunPathRes> paths;
+
+    private ArtRunResultParticipantRes(Long userId, String nickname, String profileImage,
+                                       Double distance, Integer durationSeconds, List<RunPathRes> paths) {
+        this.userId = userId;
+        this.nickname = nickname;
+        this.profileImage = profileImage;
+        this.distance = distance;
+        this.durationSeconds = durationSeconds;
+        this.paths = paths;
+    }
+
+    public static ArtRunResultParticipantRes of(ArtRunParticipant participant, RunRecord record) {
+        User user = participant.getUser();
+        if (record == null) {
+            return new ArtRunResultParticipantRes(user.getId(), user.getNickname(), user.getProfileImage(),
+                    0.0, 0, List.of());
+        }
+
+        List<RunPathRes> paths = record.getPaths().stream()
+                .map(RunPathRes::of)
+                .toList();
+        return new ArtRunResultParticipantRes(user.getId(), user.getNickname(), user.getProfileImage(),
+                record.getDistance().doubleValue(), record.getDurationSeconds(), paths);
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunResultRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/dto/response/ArtRunResultRes.java
@@ -1,0 +1,52 @@
+package com._s3k.runsync.domain.artrun.dto.response;
+
+import com._s3k.runsync.entity.ArtRunSession;
+import com._s3k.runsync.entity.enums.ArtRunStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.util.Arrays;
+import java.util.List;
+
+@Getter
+@Schema(description = "협동 러닝 결과")
+public class ArtRunResultRes {
+
+    @Schema(description = "세션 ID", example = "100")
+    private final Long sessionId;
+
+    @Schema(description = "모집 제목", example = "강아지런 같이 그려요")
+    private final String title;
+
+    @Schema(description = "세션 상태", example = "COMPLETED")
+    private final ArtRunStatus status;
+
+    @Schema(description = "도안(원본) 좌표")
+    private final List<CoordinateRes> designCoordinates;
+
+    @Schema(description = "참가자별 결과")
+    private final List<ArtRunResultParticipantRes> participants;
+
+    private ArtRunResultRes(Long sessionId, String title, ArtRunStatus status,
+                           List<CoordinateRes> designCoordinates, List<ArtRunResultParticipantRes> participants) {
+        this.sessionId = sessionId;
+        this.title = title;
+        this.status = status;
+        this.designCoordinates = designCoordinates;
+        this.participants = participants;
+    }
+
+    public static ArtRunResultRes of(ArtRunSession session, List<ArtRunResultParticipantRes> participants) {
+        List<CoordinateRes> designCoordinates = Arrays.stream(session.getRoutePath().getCoordinates())
+                .map(c -> CoordinateRes.of(c.getY(), c.getX()))
+                .toList();
+
+        return new ArtRunResultRes(
+                session.getId(),
+                session.getTitle(),
+                session.getStatus(),
+                designCoordinates,
+                participants
+        );
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/artrun/exception/ArtRunErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/exception/ArtRunErrorCode.java
@@ -18,7 +18,8 @@ public enum ArtRunErrorCode implements ResultCode {
     NOT_HOST(HttpStatus.FORBIDDEN, 5007, "호스트만 가능한 작업입니다."),
     INVALID_STATUS_TRANSITION(HttpStatus.CONFLICT, 5008, "잘못된 상태 변경입니다."),
     ARTRUN_NOT_IN_PROGRESS(HttpStatus.CONFLICT, 5009, "진행 중인 협동 러닝이 아닙니다."),
-    RESULT_ACCESS_DENIED(HttpStatus.FORBIDDEN, 5010, "참가자만 결과를 조회할 수 있습니다.");
+    RESULT_ACCESS_DENIED(HttpStatus.FORBIDDEN, 5010, "참가자만 결과를 조회할 수 있습니다."),
+    ARTRUN_NOT_COMPLETED(HttpStatus.CONFLICT, 5011, "종료된 협동 러닝만 결과를 조회할 수 있습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/domain/artrun/exception/ArtRunErrorCode.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/exception/ArtRunErrorCode.java
@@ -17,7 +17,8 @@ public enum ArtRunErrorCode implements ResultCode {
     HOST_CANNOT_LEAVE(HttpStatus.CONFLICT, 5006, "호스트는 참가를 취소할 수 없습니다."),
     NOT_HOST(HttpStatus.FORBIDDEN, 5007, "호스트만 가능한 작업입니다."),
     INVALID_STATUS_TRANSITION(HttpStatus.CONFLICT, 5008, "잘못된 상태 변경입니다."),
-    ARTRUN_NOT_IN_PROGRESS(HttpStatus.CONFLICT, 5009, "진행 중인 협동 러닝이 아닙니다.");
+    ARTRUN_NOT_IN_PROGRESS(HttpStatus.CONFLICT, 5009, "진행 중인 협동 러닝이 아닙니다."),
+    RESULT_ACCESS_DENIED(HttpStatus.FORBIDDEN, 5010, "참가자만 결과를 조회할 수 있습니다.");
 
     private final HttpStatus status;
     private final int code;

--- a/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
@@ -7,6 +7,8 @@ import com._s3k.runsync.domain.artrun.dto.request.MeetingPlaceReq;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunCreateRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunDetailRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunRes;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunResultParticipantRes;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunResultRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunScrollRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunStatusRes;
 import com._s3k.runsync.domain.artrun.dto.response.ParticipantRes;
@@ -16,10 +18,12 @@ import com._s3k.runsync.domain.artrun.exception.ArtRunErrorCode;
 import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
 import com._s3k.runsync.domain.artrun.repository.ArtRunSessionRepository;
 import com._s3k.runsync.domain.artrun.repository.ParticipantCountProjection;
+import com._s3k.runsync.domain.run.repository.RunRecordRepository;
 import com._s3k.runsync.domain.users.exception.UserErrorCode;
 import com._s3k.runsync.domain.users.repository.UserRepository;
 import com._s3k.runsync.entity.ArtRunParticipant;
 import com._s3k.runsync.entity.ArtRunSession;
+import com._s3k.runsync.entity.RunRecord;
 import com._s3k.runsync.entity.User;
 import com._s3k.runsync.entity.enums.ArtRunStatus;
 import com._s3k.runsync.global.common.ScrollPaginationCollection;
@@ -37,6 +41,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 @Service
@@ -48,6 +53,7 @@ public class ArtRunService {
     private final UserRepository userRepository;
     private final ArtRunSessionRepository artRunSessionRepository;
     private final ArtRunParticipantRepository artRunParticipantRepository;
+    private final RunRecordRepository runRecordRepository;
     private final ApplicationEventPublisher eventPublisher;
 
     @Transactional
@@ -95,6 +101,26 @@ public class ArtRunService {
                 .toList();
 
         return ArtRunDetailRes.of(session, participants.size(), participants);
+    }
+
+    @Transactional(readOnly = true)
+    public ArtRunResultRes getArtRunResultBySessionId(Long userId, Long sessionId) {
+        ArtRunSession session = artRunSessionRepository.findByIdWithHost(sessionId)
+                .orElseThrow(() -> new GlobalException(ArtRunErrorCode.SESSION_NOT_FOUND));
+
+        if (!session.isHost(userId)
+                && !artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(sessionId, userId)) {
+            throw new GlobalException(ArtRunErrorCode.RESULT_ACCESS_DENIED);
+        }
+
+        Map<Long, RunRecord> recordByUserId = runRecordRepository.findByArtRunSessionIdWithPaths(sessionId).stream()
+                .collect(Collectors.toMap(RunRecord::getUserId, Function.identity(), (a, b) -> a));
+
+        List<ArtRunResultParticipantRes> participants = artRunParticipantRepository.findByArtRunSessionIdWithUser(sessionId).stream()
+                .map(p -> ArtRunResultParticipantRes.of(p, recordByUserId.get(p.getUser().getId())))
+                .toList();
+
+        return ArtRunResultRes.of(session, participants);
     }
 
     @Transactional

--- a/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
+++ b/src/main/java/com/_s3k/runsync/domain/artrun/service/ArtRunService.java
@@ -113,6 +113,8 @@ public class ArtRunService {
             throw new GlobalException(ArtRunErrorCode.RESULT_ACCESS_DENIED);
         }
 
+        session.validateCompleted();
+
         Map<Long, RunRecord> recordByUserId = runRecordRepository.findByArtRunSessionIdWithPaths(sessionId).stream()
                 .collect(Collectors.toMap(RunRecord::getUserId, Function.identity(), (a, b) -> a));
 

--- a/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
@@ -24,6 +24,10 @@ public interface RunRecordRepository extends JpaRepository<RunRecord, Long> {
     @Query("SELECT r FROM RunRecord r LEFT JOIN FETCH r.paths WHERE r.id = :recordId")
     Optional<RunRecord> findByIdWithPaths(@Param("recordId") Long recordId);
 
+    @Query("SELECT DISTINCT r FROM RunRecord r LEFT JOIN FETCH r.paths " +
+            "JOIN r.runningSession s WHERE s.artRunSessionId = :artRunSessionId")
+    List<RunRecord> findByArtRunSessionIdWithPaths(@Param("artRunSessionId") Long artRunSessionId);
+
     @Query("""
             SELECT r FROM RunRecord r
             WHERE r.user.id IN :userIds

--- a/src/main/java/com/_s3k/runsync/entity/ArtRunSession.java
+++ b/src/main/java/com/_s3k/runsync/entity/ArtRunSession.java
@@ -108,4 +108,10 @@ public class ArtRunSession extends BaseEntity {
             throw new GlobalException(ArtRunErrorCode.ARTRUN_NOT_IN_PROGRESS);
         }
     }
+
+    public void validateCompleted() {
+        if (this.status != ArtRunStatus.COMPLETED) {
+            throw new GlobalException(ArtRunErrorCode.ARTRUN_NOT_COMPLETED);
+        }
+    }
 }

--- a/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
@@ -497,6 +497,7 @@ class ArtRunServiceTest {
         // given
         Long sessionId = 100L;
         ArtRunSession session = session(sessionId, "강아지런"); // host id == 100
+        ReflectionTestUtils.setField(session, "status", ArtRunStatus.COMPLETED);
         given(artRunSessionRepository.findByIdWithHost(sessionId)).willReturn(Optional.of(session));
         given(artRunParticipantRepository.findByArtRunSessionIdWithUser(sessionId)).willReturn(List.of());
         given(runRecordRepository.findByArtRunSessionIdWithPaths(sessionId)).willReturn(List.of());
@@ -506,6 +507,22 @@ class ArtRunServiceTest {
 
         // then
         assertThat(result.getParticipants()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("종료되지 않은(IN_PROGRESS) 세션 결과 조회 시 예외 발생")
+    void getArtRunResult_notCompleted() {
+        // given
+        Long sessionId = 100L;
+        ArtRunSession session = session(sessionId, "강아지런"); // host id == 100
+        ReflectionTestUtils.setField(session, "status", ArtRunStatus.IN_PROGRESS);
+        given(artRunSessionRepository.findByIdWithHost(sessionId)).willReturn(Optional.of(session));
+
+        // when & then (호스트라 권한은 통과, 상태 검증에서 막힘)
+        assertThatThrownBy(() -> artRunService.getArtRunResultBySessionId(100L, sessionId))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.ARTRUN_NOT_COMPLETED));
     }
 
     @Test

--- a/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/artrun/service/ArtRunServiceTest.java
@@ -5,6 +5,8 @@ import com._s3k.runsync.domain.artrun.dto.request.ArtRunStatusUpdateReq;
 import com._s3k.runsync.domain.artrun.dto.request.CoordinateReq;
 import com._s3k.runsync.domain.artrun.dto.request.MeetingPlaceReq;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunDetailRes;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunResultParticipantRes;
+import com._s3k.runsync.domain.artrun.dto.response.ArtRunResultRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunScrollRes;
 import com._s3k.runsync.domain.artrun.dto.response.ArtRunStatusRes;
 import com._s3k.runsync.domain.artrun.event.ArtRunParticipantLeftEvent;
@@ -13,10 +15,13 @@ import com._s3k.runsync.domain.artrun.exception.ArtRunErrorCode;
 import com._s3k.runsync.domain.artrun.repository.ArtRunParticipantRepository;
 import com._s3k.runsync.domain.artrun.repository.ArtRunSessionRepository;
 import com._s3k.runsync.domain.artrun.repository.ParticipantCountProjection;
+import com._s3k.runsync.domain.run.repository.RunRecordRepository;
 import com._s3k.runsync.domain.users.exception.UserErrorCode;
 import com._s3k.runsync.domain.users.repository.UserRepository;
 import com._s3k.runsync.entity.ArtRunParticipant;
 import com._s3k.runsync.entity.ArtRunSession;
+import com._s3k.runsync.entity.RunPath;
+import com._s3k.runsync.entity.RunRecord;
 import com._s3k.runsync.entity.User;
 import com._s3k.runsync.entity.enums.ArtRunStatus;
 import com._s3k.runsync.entity.enums.Provider;
@@ -37,6 +42,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -65,6 +71,9 @@ class ArtRunServiceTest {
 
     @Mock
     private ArtRunParticipantRepository artRunParticipantRepository;
+
+    @Mock
+    private RunRecordRepository runRecordRepository;
 
     @Mock
     private ApplicationEventPublisher eventPublisher;
@@ -443,6 +452,92 @@ class ArtRunServiceTest {
                         .isEqualTo(ArtRunErrorCode.SESSION_NOT_FOUND));
     }
 
+    @Test
+    @DisplayName("협동 러닝 결과 조회 성공 - 뛴 참가자는 기록, 안 뛴 참가자는 빈 경로(paths=[])로 포함된다")
+    void getArtRunResult_success() {
+        // given
+        Long sessionId = 100L;
+        Long runnerId = 10L;
+        Long nonRunnerId = 11L;
+        ArtRunSession session = session(sessionId, "강아지런");
+        ReflectionTestUtils.setField(session, "status", ArtRunStatus.COMPLETED);
+
+        given(artRunSessionRepository.findByIdWithHost(sessionId)).willReturn(Optional.of(session));
+        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(sessionId, runnerId)).willReturn(true);
+        given(artRunParticipantRepository.findByArtRunSessionIdWithUser(sessionId))
+                .willReturn(List.of(participant(runnerId, "러너", session), participant(nonRunnerId, "구경꾼", session)));
+        given(runRecordRepository.findByArtRunSessionIdWithPaths(sessionId))
+                .willReturn(List.of(runRecord(runnerId, 2.59, 1048)));
+
+        // when
+        ArtRunResultRes result = artRunService.getArtRunResultBySessionId(runnerId, sessionId);
+
+        // then
+        assertThat(result.getSessionId()).isEqualTo(sessionId);
+        assertThat(result.getStatus()).isEqualTo(ArtRunStatus.COMPLETED);
+        assertThat(result.getDesignCoordinates()).hasSize(2);
+        assertThat(result.getParticipants()).hasSize(2);
+
+        ArtRunResultParticipantRes runner = result.getParticipants().stream()
+                .filter(p -> p.getUserId().equals(runnerId)).findFirst().orElseThrow();
+        assertThat(runner.getDistance()).isEqualTo(2.59);
+        assertThat(runner.getDurationSeconds()).isEqualTo(1048);
+        assertThat(runner.getPaths()).hasSize(1);
+
+        ArtRunResultParticipantRes nonRunner = result.getParticipants().stream()
+                .filter(p -> p.getUserId().equals(nonRunnerId)).findFirst().orElseThrow();
+        assertThat(nonRunner.getDistance()).isEqualTo(0.0);
+        assertThat(nonRunner.getDurationSeconds()).isEqualTo(0);
+        assertThat(nonRunner.getPaths()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("호스트는 참가자가 아니어도 결과를 조회할 수 있다")
+    void getArtRunResult_hostCanView() {
+        // given
+        Long sessionId = 100L;
+        ArtRunSession session = session(sessionId, "강아지런"); // host id == 100
+        given(artRunSessionRepository.findByIdWithHost(sessionId)).willReturn(Optional.of(session));
+        given(artRunParticipantRepository.findByArtRunSessionIdWithUser(sessionId)).willReturn(List.of());
+        given(runRecordRepository.findByArtRunSessionIdWithPaths(sessionId)).willReturn(List.of());
+
+        // when
+        ArtRunResultRes result = artRunService.getArtRunResultBySessionId(100L, sessionId);
+
+        // then
+        assertThat(result.getParticipants()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("참가자도 호스트도 아니면 결과 조회 시 예외 발생")
+    void getArtRunResult_accessDenied() {
+        // given
+        Long sessionId = 100L;
+        Long strangerId = 99L;
+        ArtRunSession session = session(sessionId, "강아지런"); // host id == 100
+        given(artRunSessionRepository.findByIdWithHost(sessionId)).willReturn(Optional.of(session));
+        given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(sessionId, strangerId)).willReturn(false);
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.getArtRunResultBySessionId(strangerId, sessionId))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.RESULT_ACCESS_DENIED));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 세션 결과 조회 시 예외 발생")
+    void getArtRunResult_sessionNotFound() {
+        // given
+        given(artRunSessionRepository.findByIdWithHost(1L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> artRunService.getArtRunResultBySessionId(1L, 1L))
+                .isInstanceOf(GlobalException.class)
+                .satisfies(e -> assertThat(((GlobalException) e).getResultCode())
+                        .isEqualTo(ArtRunErrorCode.SESSION_NOT_FOUND));
+    }
+
     private ArtRunStatusUpdateReq statusReq(ArtRunStatus status) {
         ArtRunStatusUpdateReq request = new ArtRunStatusUpdateReq();
         ReflectionTestUtils.setField(request, "status", status);
@@ -468,6 +563,16 @@ class ArtRunServiceTest {
         User user = User.createTmpUser(Provider.KAKAO, "kakao" + userId, nickname, null);
         ReflectionTestUtils.setField(user, "id", userId);
         return ArtRunParticipant.of(session, user);
+    }
+
+    private RunRecord runRecord(Long userId, double distance, int durationSeconds) {
+        User user = User.createTmpUser(Provider.KAKAO, "kakao" + userId, "nick" + userId, null);
+        ReflectionTestUtils.setField(user, "id", userId);
+        RunRecord record = RunRecord.of(user, null, durationSeconds, LocalDateTime.now(),
+                BigDecimal.valueOf(distance), null, null, null, null, null);
+        ReflectionTestUtils.setField(record, "userId", userId);
+        record.addPaths(List.of(RunPath.of(record, 37.5, 127.0, 1, LocalDateTime.now(), null, null)));
+        return record;
     }
 
     private ParticipantCountProjection countProjection(Long sessionId, Long count) {


### PR DESCRIPTION
## #️⃣연관된 이슈

> #66 

## 📝작업 내용

- `GET /api/art-runs/{sessionId}/result` 추가 — 참가자/호스트만 조회(비참가자 403), 종료 후 결과 조회용
- 응답: 도안 좌표(designCoordinates) + 참가자별 { 거리, 시간, 경로(paths) }
- 참가자별 기록은 개인 RunRecord 재사용해 조합 (`LEFT JOIN FETCH`로 N+1 방지)
- 참가했지만 안 뛴 참가자도 `paths: []`, `distance: 0` 으로 포함
- `RESULT_ACCESS_DENIED(403)` 에러코드 추가
- 단위 테스트: 결과 매핑 / 호스트 조회 / 비참가자 403 / 세션 없음

## 📷스크린샷 

<img width="1227" height="1096" alt="스크린샷 2026-06-10 오전 2 37 26" src="https://github.com/user-attachments/assets/fa5cb1b8-5e60-4094-b2ae-00be3416a272" />
