### PR TITLE
[Feat] 진행 중 러닝 세션 조회 + 버려진 세션 자동정리

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
@@ -43,7 +43,7 @@ public class RunSessionController {
     public CommonResponse<RunSessionActiveRes> getActiveRunSession(
             @AuthenticationPrincipal Long userId
     ) {
-        return CommonResponse.success(runSessionService.getActiveRunSession(userId));
+        return CommonResponse.success(runSessionService.getActiveRunSession(userId).orElse(null));
     }
 
     @PatchMapping("/{sessionId}/location")

--- a/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/controller/RunSessionController.java
@@ -5,6 +5,7 @@ import com._s3k.runsync.domain.run.dto.request.RunRecordDetailReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionEndReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
 import com._s3k.runsync.domain.run.dto.response.RunRecordDetailRes;
+import com._s3k.runsync.domain.run.dto.response.RunSessionActiveRes;
 import com._s3k.runsync.domain.run.dto.response.RunSessionEndRes;
 import com._s3k.runsync.domain.run.dto.response.RunSessionStartRes;
 import com._s3k.runsync.domain.run.service.RunSessionService;
@@ -13,6 +14,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -34,6 +36,14 @@ public class RunSessionController {
             @Valid @RequestBody RunSessionStartReq request
     ) {
         return CommonResponse.success(runSessionService.createRunSession(userId, request));
+    }
+
+    @GetMapping("/active")
+    @Operation(summary = "진행 중 러닝 세션 조회", description = "현재 진행 중(ACTIVE)인 러닝 세션을 조회합니다. 없으면 data가 null입니다. 로그인 필요")
+    public CommonResponse<RunSessionActiveRes> getActiveRunSession(
+            @AuthenticationPrincipal Long userId
+    ) {
+        return CommonResponse.success(runSessionService.getActiveRunSession(userId));
     }
 
     @PatchMapping("/{sessionId}/location")

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunSessionActiveRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunSessionActiveRes.java
@@ -1,0 +1,42 @@
+package com._s3k.runsync.domain.run.dto.response;
+
+import com._s3k.runsync.entity.RunningSession;
+import com._s3k.runsync.entity.enums.RunningSessionStatus;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Schema(description = "진행 중 러닝 세션 조회 응답")
+public class RunSessionActiveRes {
+
+    @Schema(description = "세션 ID", example = "1")
+    private final Long sessionId;
+
+    @Schema(description = "세션 상태", example = "ACTIVE")
+    private final RunningSessionStatus status;
+
+    @Schema(description = "러닝 시작 시간", example = "2026-06-10T22:11:00")
+    private final LocalDateTime startTime;
+
+    @Schema(description = "연결된 협동 러닝 세션 ID (일반 러닝이면 null)", example = "100")
+    private final Long artRunSessionId;
+
+    private RunSessionActiveRes(Long sessionId, RunningSessionStatus status,
+                               LocalDateTime startTime, Long artRunSessionId) {
+        this.sessionId = sessionId;
+        this.status = status;
+        this.startTime = startTime;
+        this.artRunSessionId = artRunSessionId;
+    }
+
+    public static RunSessionActiveRes of(RunningSession session) {
+        return new RunSessionActiveRes(
+                session.getId(),
+                session.getStatus(),
+                session.getStartTime(),
+                session.getArtRunSessionId()
+        );
+    }
+}

--- a/src/main/java/com/_s3k/runsync/domain/run/repository/RunningSessionRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/RunningSessionRepository.java
@@ -9,8 +9,6 @@ import java.util.Optional;
 
 public interface RunningSessionRepository extends JpaRepository<RunningSession, Long> {
 
-    boolean existsByUserIdAndStatus(Long userId, RunningSessionStatus status);
-
     Optional<RunningSession> findByUserIdAndStatus(Long userId, RunningSessionStatus status);
 
     List<RunningSession> findByUserIdInAndStatus(List<Long> userIds, RunningSessionStatus status);

--- a/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
@@ -41,6 +41,7 @@ import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -95,10 +96,9 @@ public class RunSessionService {
     }
 
     @Transactional(readOnly = true)
-    public RunSessionActiveRes getActiveRunSession(Long userId) {
+    public Optional<RunSessionActiveRes> getActiveRunSession(Long userId) {
         return runningSessionRepository.findByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)
-                .map(RunSessionActiveRes::of)
-                .orElse(null);
+                .map(RunSessionActiveRes::of);
     }
 
     @Transactional

--- a/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/service/RunSessionService.java
@@ -9,6 +9,7 @@ import com._s3k.runsync.domain.run.dto.request.RunRecordDetailReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionEndReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
 import com._s3k.runsync.domain.run.dto.response.RunRecordDetailRes;
+import com._s3k.runsync.domain.run.dto.response.RunSessionActiveRes;
 import com._s3k.runsync.domain.run.dto.response.RunSessionEndRes;
 import com._s3k.runsync.domain.run.dto.response.RunSessionStartRes;
 import com._s3k.runsync.domain.run.exception.RunSessionErrorCode;
@@ -33,6 +34,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Clock;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
@@ -54,6 +56,7 @@ public class RunSessionService {
     private final ArtRunParticipantRepository artRunParticipantRepository;
     private final ArtRunSessionRepository artRunSessionRepository;
     private final ObjectMapper objectMapper;
+    private final Clock clock;
 
 
     @Transactional
@@ -61,10 +64,15 @@ public class RunSessionService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new GlobalException(UserErrorCode.USER_NOT_FOUND));
 
-        // 일반적인 경우 서비스 레벨에서 차단
-        if (runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)) {
-            throw new GlobalException(RunSessionErrorCode.ACTIVE_SESSION_ALREADY_EXISTS);
-        }
+        // 진행 중 세션이 있으면: 오래 방치된 세션은 자동 정리, 최근 세션은 차단
+        runningSessionRepository.findByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)
+                .ifPresent(active -> {
+                    if (!active.isStale(LocalDateTime.now(clock))) {
+                        throw new GlobalException(RunSessionErrorCode.ACTIVE_SESSION_ALREADY_EXISTS);
+                    }
+                    active.abandon();
+                    runningSessionRepository.saveAndFlush(active);
+                });
 
         Long artRunSessionId = request.getArtRunSessionId();
         if (artRunSessionId != null) {
@@ -84,6 +92,13 @@ public class RunSessionService {
             // 동시 요청 시 DB 유니크 인덱스(idx_user_active_session)가 잡아주는 케이스
             throw new GlobalException(RunSessionErrorCode.ACTIVE_SESSION_ALREADY_EXISTS);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public RunSessionActiveRes getActiveRunSession(Long userId) {
+        return runningSessionRepository.findByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)
+                .map(RunSessionActiveRes::of)
+                .orElse(null);
     }
 
     @Transactional

--- a/src/main/java/com/_s3k/runsync/entity/RunningSession.java
+++ b/src/main/java/com/_s3k/runsync/entity/RunningSession.java
@@ -25,6 +25,7 @@ import java.util.Objects;
 public class RunningSession extends BaseEntity {
 
     private static final GeometryFactory GEOMETRY_FACTORY = new GeometryFactory(new PrecisionModel(), 4326);
+    private static final long STALE_THRESHOLD_HOURS = 12;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -123,6 +124,14 @@ public class RunningSession extends BaseEntity {
 
     public void resume() {
         this.status = RunningSessionStatus.ACTIVE;
+    }
+
+    public boolean isStale(LocalDateTime now) {
+        return this.startTime.isBefore(now.minusHours(STALE_THRESHOLD_HOURS));
+    }
+
+    public void abandon() {
+        this.status = RunningSessionStatus.ABANDONED;
     }
 
 }

--- a/src/main/java/com/_s3k/runsync/entity/enums/RunningSessionStatus.java
+++ b/src/main/java/com/_s3k/runsync/entity/enums/RunningSessionStatus.java
@@ -6,5 +6,6 @@ import lombok.Getter;
 public enum RunningSessionStatus {
     ACTIVE,
     PAUSED,
-    COMPLETED
+    COMPLETED,
+    ABANDONED
 }

--- a/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
@@ -8,6 +8,7 @@ import com._s3k.runsync.domain.run.dto.request.LocationUpdateReq;
 import com._s3k.runsync.domain.run.dto.request.RunRecordDetailReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionEndReq;
 import com._s3k.runsync.domain.run.dto.request.RunSessionStartReq;
+import com._s3k.runsync.domain.run.dto.response.RunSessionActiveRes;
 import com._s3k.runsync.domain.run.exception.RunSessionErrorCode;
 import com._s3k.runsync.domain.run.repository.RunRecordRepository;
 import com._s3k.runsync.domain.run.repository.RunSessionRedisRepository;
@@ -33,7 +34,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.math.BigDecimal;
+import java.time.Clock;
+import java.time.Instant;
 import java.time.LocalDateTime;
+import java.time.ZoneOffset;
 import java.util.List;
 import java.util.Optional;
 
@@ -76,6 +80,9 @@ class RunSessionServiceTest {
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
 
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-06-10T00:00:00Z"), ZoneOffset.UTC);
+
     @Test
     @DisplayName("러닝 세션 생성 성공")
     void createRunSession_success() {
@@ -86,7 +93,7 @@ class RunSessionServiceTest {
 
         User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(false);
+        given(runningSessionRepository.findByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(Optional.empty());
         given(runningSessionRepository.save(any(RunningSession.class))).willAnswer(i -> i.getArgument(0));
 
         // when
@@ -116,7 +123,7 @@ class RunSessionServiceTest {
     }
 
     @Test
-    @DisplayName("이미 진행 중인 세션이 있을 때 예외 발생")
+    @DisplayName("최근 진행 중인 세션이 있으면 예외 발생")
     void createRunSession_activeSessionAlreadyExists() {
         // given
         Long userId = 1L;
@@ -124,8 +131,10 @@ class RunSessionServiceTest {
         ReflectionTestUtils.setField(request, "startTime", LocalDateTime.now());
 
         User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession active = mock(RunningSession.class);
+        given(active.isStale(any())).willReturn(false);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(true);
+        given(runningSessionRepository.findByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(Optional.of(active));
 
         // when & then
         assertThatThrownBy(() -> runSessionService.createRunSession(userId, request))
@@ -134,6 +143,66 @@ class RunSessionServiceTest {
                         .isEqualTo(RunSessionErrorCode.ACTIVE_SESSION_ALREADY_EXISTS));
 
         verify(runningSessionRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("오래 방치된 ACTIVE 세션은 자동 정리되고 새 세션이 시작된다")
+    void createRunSession_staleSessionAutoAbandoned() {
+        // given
+        Long userId = 1L;
+        RunSessionStartReq request = new RunSessionStartReq();
+        ReflectionTestUtils.setField(request, "startTime", LocalDateTime.now());
+
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession stale = mock(RunningSession.class);
+        given(stale.isStale(any())).willReturn(true);
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(runningSessionRepository.findByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(Optional.of(stale));
+        given(runningSessionRepository.save(any(RunningSession.class))).willAnswer(i -> i.getArgument(0));
+
+        // when
+        runSessionService.createRunSession(userId, request);
+
+        // then
+        verify(stale).abandon();
+        verify(runningSessionRepository).saveAndFlush(stale);
+        verify(runningSessionRepository).save(any(RunningSession.class));
+    }
+
+    @Test
+    @DisplayName("진행 중 세션 조회 - 있으면 세션 정보를 반환한다")
+    void getActiveRunSession_exists() {
+        // given
+        Long userId = 1L;
+        User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
+        RunningSession session = RunningSession.of(user, LocalDateTime.now(), 100L);
+        ReflectionTestUtils.setField(session, "id", 5L);
+        given(runningSessionRepository.findByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE))
+                .willReturn(Optional.of(session));
+
+        // when
+        RunSessionActiveRes result = runSessionService.getActiveRunSession(userId);
+
+        // then
+        assertThat(result).isNotNull();
+        assertThat(result.getSessionId()).isEqualTo(5L);
+        assertThat(result.getArtRunSessionId()).isEqualTo(100L);
+        assertThat(result.getStatus()).isEqualTo(RunningSessionStatus.ACTIVE);
+    }
+
+    @Test
+    @DisplayName("진행 중 세션 조회 - 없으면 null을 반환한다")
+    void getActiveRunSession_none() {
+        // given
+        Long userId = 1L;
+        given(runningSessionRepository.findByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE))
+                .willReturn(Optional.empty());
+
+        // when
+        RunSessionActiveRes result = runSessionService.getActiveRunSession(userId);
+
+        // then
+        assertThat(result).isNull();
     }
 
     @Test
@@ -149,7 +218,7 @@ class RunSessionServiceTest {
         User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
         ArtRunSession artRunSession = mock(ArtRunSession.class);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(false);
+        given(runningSessionRepository.findByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(Optional.empty());
         given(artRunSessionRepository.findById(artRunSessionId)).willReturn(Optional.of(artRunSession));
         given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(artRunSessionId, userId)).willReturn(true);
         given(runningSessionRepository.save(any(RunningSession.class))).willAnswer(i -> i.getArgument(0));
@@ -176,7 +245,7 @@ class RunSessionServiceTest {
 
         User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(false);
+        given(runningSessionRepository.findByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(Optional.empty());
         given(artRunSessionRepository.findById(artRunSessionId)).willReturn(Optional.of(mock(ArtRunSession.class)));
         given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(artRunSessionId, userId)).willReturn(false);
 
@@ -201,7 +270,7 @@ class RunSessionServiceTest {
 
         User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(false);
+        given(runningSessionRepository.findByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(Optional.empty());
         given(artRunSessionRepository.findById(artRunSessionId)).willReturn(Optional.empty());
 
         // when & then
@@ -226,7 +295,7 @@ class RunSessionServiceTest {
         User user = User.createTmpUser(Provider.KAKAO, "kakaoId", "nickname", null);
         ArtRunSession artRunSession = mock(ArtRunSession.class);
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(runningSessionRepository.existsByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(false);
+        given(runningSessionRepository.findByUserIdAndStatus(userId, RunningSessionStatus.ACTIVE)).willReturn(Optional.empty());
         given(artRunSessionRepository.findById(artRunSessionId)).willReturn(Optional.of(artRunSession));
         given(artRunParticipantRepository.existsByArtRunSession_IdAndUser_Id(artRunSessionId, userId)).willReturn(true);
         doThrow(new GlobalException(ArtRunErrorCode.ARTRUN_NOT_IN_PROGRESS)).when(artRunSession).validateInProgress();

--- a/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
@@ -181,13 +181,13 @@ class RunSessionServiceTest {
                 .willReturn(Optional.of(session));
 
         // when
-        RunSessionActiveRes result = runSessionService.getActiveRunSession(userId);
+        Optional<RunSessionActiveRes> result = runSessionService.getActiveRunSession(userId);
 
         // then
-        assertThat(result).isNotNull();
-        assertThat(result.getSessionId()).isEqualTo(5L);
-        assertThat(result.getArtRunSessionId()).isEqualTo(100L);
-        assertThat(result.getStatus()).isEqualTo(RunningSessionStatus.ACTIVE);
+        assertThat(result).isPresent();
+        assertThat(result.get().getSessionId()).isEqualTo(5L);
+        assertThat(result.get().getArtRunSessionId()).isEqualTo(100L);
+        assertThat(result.get().getStatus()).isEqualTo(RunningSessionStatus.ACTIVE);
     }
 
     @Test
@@ -199,10 +199,10 @@ class RunSessionServiceTest {
                 .willReturn(Optional.empty());
 
         // when
-        RunSessionActiveRes result = runSessionService.getActiveRunSession(userId);
+        Optional<RunSessionActiveRes> result = runSessionService.getActiveRunSession(userId);
 
         // then
-        assertThat(result).isNull();
+        assertThat(result).isEmpty();
     }
 
     @Test


### PR DESCRIPTION
## #️⃣연관된 이슈

> #69 

## 📝작업 내용

- `GET /api/run-sessions/active` 추가 — 현재 진행 중 세션 조회(없으면 null), FE가 "이어뛰기/종료" 노출용
- 러닝 시작 시 **오래 방치된(12h↑) ACTIVE 세션은 자동 정리(ABANDONED)** 후 새 세션 시작
- 최근 ACTIVE 세션이면 기존대로 409 (이어뛰기 유도)
- `RunningSession.isStale()/abandon()` 엔티티 메서드 + `ABANDONED` 상태 추가
- 자동 정리 시 `saveAndFlush`로 기존 세션 정리를 먼저 반영해 unique index 충돌 방지
- 단위 테스트: 최근세션 차단 / 오래된세션 자동정리 / 진행중세션 조회(있음·없음)
