### PR TITLE
[Feat] 프로필 완성 시 USER 승격 + 월간 통계 필드 추가

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/run/repository/MonthlyStatsProjection.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/MonthlyStatsProjection.java
@@ -5,4 +5,5 @@ import java.math.BigDecimal;
 public interface MonthlyStatsProjection {
     BigDecimal getTotalDistance();
     Long getTotalRunCount();
+    Long getTotalDurationSeconds();
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/repository/RunRecordRepository.java
@@ -14,7 +14,7 @@ public interface RunRecordRepository extends JpaRepository<RunRecord, Long> {
 
     Optional<RunRecord> findByRunningSessionId(Long sessionId);
 
-    @Query("SELECT COALESCE(SUM(r.distance), 0) AS totalDistance, COUNT(r) AS totalRunCount FROM RunRecord r WHERE r.user.id = :userId AND r.startTime >= :start AND r.startTime < :end")
+    @Query("SELECT COALESCE(SUM(r.distance), 0) AS totalDistance, COUNT(r) AS totalRunCount, COALESCE(SUM(r.durationSeconds), 0) AS totalDurationSeconds FROM RunRecord r WHERE r.user.id = :userId AND r.startTime >= :start AND r.startTime < :end")
     MonthlyStatsProjection findMonthlyStats(@Param("userId") Long userId, @Param("start") LocalDateTime start, @Param("end") LocalDateTime end);
 
     List<RunRecord> findByUserIdOrderByIdDesc(Long userId, Pageable pageable);

--- a/src/main/java/com/_s3k/runsync/domain/users/dto/response/UserSummaryRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/dto/response/UserSummaryRes.java
@@ -43,7 +43,7 @@ public class UserSummaryRes {
 
         public static MonthlyStats of(Double totalDistance, Integer totalRunCount, Integer totalDurationSeconds) {
             Double averagePace = null;
-            if (totalDistance != null && totalDistance > 0) {
+            if (totalDistance != null && totalDistance > 0 && totalDurationSeconds != null) {
                 averagePace = Math.round((totalDurationSeconds / 60.0 / totalDistance) * 100) / 100.0;
             }
             return new MonthlyStats(totalDistance, totalRunCount, totalDurationSeconds, averagePace, MONTHLY_GOAL_KM);

--- a/src/main/java/com/_s3k/runsync/domain/users/dto/response/UserSummaryRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/dto/response/UserSummaryRes.java
@@ -19,18 +19,34 @@ public class UserSummaryRes {
     @Schema(description = "월간 러닝 통계")
     public static class MonthlyStats {
 
+        private static final double MONTHLY_GOAL_KM = 50.0;
+
         @Schema(description = "이번 달 총 거리 (km)", example = "25.30")
         private Double totalDistance;
         @Schema(description = "이번 달 러닝 횟수", example = "5")
         private Integer totalRunCount;
+        @Schema(description = "이번 달 총 러닝 시간 (초)", example = "9000")
+        private Integer totalDurationSeconds;
+        @Schema(description = "이번 달 평균 페이스 (분/km), 기록 없으면 null", example = "6.43")
+        private Double averagePace;
+        @Schema(description = "이번 달 목표 거리 (km)", example = "50.0")
+        private Double monthlyGoalKm;
 
-        private MonthlyStats(Double totalDistance, Integer totalRunCount) {
+        private MonthlyStats(Double totalDistance, Integer totalRunCount, Integer totalDurationSeconds,
+                             Double averagePace, Double monthlyGoalKm) {
             this.totalDistance = totalDistance;
             this.totalRunCount = totalRunCount;
+            this.totalDurationSeconds = totalDurationSeconds;
+            this.averagePace = averagePace;
+            this.monthlyGoalKm = monthlyGoalKm;
         }
 
-        public static MonthlyStats of(Double totalDistance, Integer totalRunCount) {
-            return new MonthlyStats(totalDistance, totalRunCount);
+        public static MonthlyStats of(Double totalDistance, Integer totalRunCount, Integer totalDurationSeconds) {
+            Double averagePace = null;
+            if (totalDistance != null && totalDistance > 0) {
+                averagePace = Math.round((totalDurationSeconds / 60.0 / totalDistance) * 100) / 100.0;
+            }
+            return new MonthlyStats(totalDistance, totalRunCount, totalDurationSeconds, averagePace, MONTHLY_GOAL_KM);
         }
     }
 
@@ -40,11 +56,11 @@ public class UserSummaryRes {
         this.monthlyStats = monthlyStats;
     }
 
-    public static UserSummaryRes of(User user, Double totalDistance, Integer totalRunCount) {
+    public static UserSummaryRes of(User user, Double totalDistance, Integer totalRunCount, Integer totalDurationSeconds) {
         return new UserSummaryRes(
                 user.getNickname(),
                 user.getProfileImage(),
-                MonthlyStats.of(totalDistance, totalRunCount)
+                MonthlyStats.of(totalDistance, totalRunCount, totalDurationSeconds)
         );
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/users/service/UserService.java
+++ b/src/main/java/com/_s3k/runsync/domain/users/service/UserService.java
@@ -78,7 +78,7 @@ public class UserService {
             throw new GlobalException(UserErrorCode.NICKNAME_ALREADY_EXISTS);
         }
 
-        if (user.getRole() == Role.TMP_USER && request.getNickname() != null && !request.getNickname().isBlank()) {
+        if (user.getRole() == Role.TMP_USER && user.isProfileComplete()) {
             user.upgradeToUser();
         }
 
@@ -95,7 +95,8 @@ public class UserService {
         LocalDateTime end = start.plusMonths(1);
 
         MonthlyStatsProjection stats = runRecordRepository.findMonthlyStats(userId, start, end);
-        return UserSummaryRes.of(user, stats.getTotalDistance().doubleValue(), stats.getTotalRunCount().intValue());
+        return UserSummaryRes.of(user, stats.getTotalDistance().doubleValue(),
+                stats.getTotalRunCount().intValue(), stats.getTotalDurationSeconds().intValue());
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/_s3k/runsync/entity/User.java
+++ b/src/main/java/com/_s3k/runsync/entity/User.java
@@ -93,6 +93,10 @@ public class User extends BaseEntity {
         this.role = Role.USER;
     }
 
+    public boolean isProfileComplete() {
+        return nickname != null && !nickname.isBlank() && gender != null && birthDate != null;
+    }
+
     /**
      * 사용자 정보 선택적 업데이트
      */

--- a/src/test/java/com/_s3k/runsync/domain/users/service/UserServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/users/service/UserServiceTest.java
@@ -2,30 +2,42 @@ package com._s3k.runsync.domain.users.service;
 
 import com._s3k.runsync.domain.friend.repository.FriendRequestRepository;
 import com._s3k.runsync.domain.friend.repository.FriendshipRepository;
+import com._s3k.runsync.domain.run.repository.MonthlyStatsProjection;
 import com._s3k.runsync.domain.run.repository.RunRecordRepository;
+import com._s3k.runsync.domain.users.dto.request.UserUpdateReq;
 import com._s3k.runsync.domain.users.dto.response.UserSearchScrollRes;
+import com._s3k.runsync.domain.users.dto.response.UserSummaryRes;
 import com._s3k.runsync.domain.users.repository.UserRepository;
 import com._s3k.runsync.entity.User;
 import com._s3k.runsync.entity.enums.FriendRequestStatus;
+import com._s3k.runsync.entity.enums.Gender;
 import com._s3k.runsync.entity.enums.Provider;
+import com._s3k.runsync.entity.enums.Role;
 import com._s3k.runsync.entity.enums.UserRelation;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.Spy;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.math.BigDecimal;
 import java.time.Clock;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
 import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyList;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -47,8 +59,8 @@ class UserServiceTest {
     @Mock
     private FriendRequestRepository friendRequestRepository;
 
-    @Mock
-    private Clock clock;
+    @Spy
+    private Clock clock = Clock.fixed(Instant.parse("2026-06-10T00:00:00Z"), ZoneOffset.UTC);
 
     @Test
     @DisplayName("닉네임 검색 성공 - 친구/보낸요청/받은요청/없음 관계가 정확히 매핑된다")
@@ -119,6 +131,93 @@ class UserServiceTest {
         assertThat(result.getNextCursor()).isEqualTo(2L);
         assertThat(result.getUsers().get(0).getId()).isEqualTo(1L);
         assertThat(result.getUsers().get(1).getId()).isEqualTo(2L);
+    }
+
+    @Test
+    @DisplayName("TMP_USER가 성별·생년월일을 채워 프로필이 완성되면 USER로 승격된다")
+    void updateMyInfo_promotesWhenProfileComplete() {
+        // given - 카카오 가입으로 닉네임은 이미 있고 성별/생년월일만 비어있는 TMP_USER
+        Long userId = 1L;
+        User tmpUser = User.createTmpUser(Provider.KAKAO, "kakao1", "현우", "img1");
+        ReflectionTestUtils.setField(tmpUser, "id", userId);
+        given(userRepository.findById(userId)).willReturn(Optional.of(tmpUser));
+
+        UserUpdateReq request = new UserUpdateReq();
+        ReflectionTestUtils.setField(request, "gender", Gender.MALE);
+        ReflectionTestUtils.setField(request, "birthDate", LocalDate.of(2000, 1, 1));
+
+        // when
+        userService.updateMyInfo(userId, request);
+
+        // then
+        assertThat(tmpUser.getRole()).isEqualTo(Role.USER);
+    }
+
+    @Test
+    @DisplayName("프로필이 미완성(생년월일 누락)이면 TMP_USER로 유지된다")
+    void updateMyInfo_staysTmpWhenIncomplete() {
+        // given
+        Long userId = 1L;
+        User tmpUser = User.createTmpUser(Provider.KAKAO, "kakao1", "현우", "img1");
+        ReflectionTestUtils.setField(tmpUser, "id", userId);
+        given(userRepository.findById(userId)).willReturn(Optional.of(tmpUser));
+
+        UserUpdateReq request = new UserUpdateReq();
+        ReflectionTestUtils.setField(request, "gender", Gender.MALE);
+
+        // when
+        userService.updateMyInfo(userId, request);
+
+        // then
+        assertThat(tmpUser.getRole()).isEqualTo(Role.TMP_USER);
+    }
+
+    @Test
+    @DisplayName("월간 통계 - 평균 페이스(분/km)와 총 시간·목표가 계산되어 반환된다")
+    void getUserSummary_computesStats() {
+        // given
+        Long userId = 1L;
+        User user = user(userId, "현우");
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        MonthlyStatsProjection stats = mock(MonthlyStatsProjection.class);
+        given(stats.getTotalDistance()).willReturn(BigDecimal.valueOf(5.0));
+        given(stats.getTotalRunCount()).willReturn(2L);
+        given(stats.getTotalDurationSeconds()).willReturn(1500L); // 25분
+        given(runRecordRepository.findMonthlyStats(eq(userId), any(), any())).willReturn(stats);
+
+        // when
+        UserSummaryRes result = userService.getUserSummary(userId);
+
+        // then
+        UserSummaryRes.MonthlyStats monthly = result.getMonthlyStats();
+        assertThat(monthly.getTotalDistance()).isEqualTo(5.0);
+        assertThat(monthly.getTotalRunCount()).isEqualTo(2);
+        assertThat(monthly.getTotalDurationSeconds()).isEqualTo(1500);
+        assertThat(monthly.getAveragePace()).isEqualTo(5.0); // 25분 / 5km
+        assertThat(monthly.getMonthlyGoalKm()).isEqualTo(50.0);
+    }
+
+    @Test
+    @DisplayName("월간 통계 - 이번 달 기록이 없으면 평균 페이스는 null이다")
+    void getUserSummary_noRecordsAveragePaceNull() {
+        // given
+        Long userId = 1L;
+        User user = user(userId, "현우");
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        MonthlyStatsProjection stats = mock(MonthlyStatsProjection.class);
+        given(stats.getTotalDistance()).willReturn(BigDecimal.ZERO);
+        given(stats.getTotalRunCount()).willReturn(0L);
+        given(stats.getTotalDurationSeconds()).willReturn(0L);
+        given(runRecordRepository.findMonthlyStats(eq(userId), any(), any())).willReturn(stats);
+
+        // when
+        UserSummaryRes result = userService.getUserSummary(userId);
+
+        // then
+        assertThat(result.getMonthlyStats().getAveragePace()).isNull();
+        assertThat(result.getMonthlyStats().getMonthlyGoalKm()).isEqualTo(50.0);
     }
 
     private User user(Long id, String nickname) {


### PR DESCRIPTION
## #️⃣연관된 이슈
> #71 

## 📝작업 내용

- TMP_USER 승격 기준을 **프로필 완성(nickname+gender+birthDate)** 으로 변경 — `User.isProfileComplete()` 엔티티 메서드로, 어떤 PATCH로 마지막 필드를 채우든 자동 승격
- `GET /api/users/me/summary` 월간 통계에 필드 추가:
    - `totalDurationSeconds` (이번 달 총 러닝 시간)
    - `averagePace` (분/km, 총시간÷총거리, 기록 없으면 null)
    - `monthlyGoalKm` (월 목표, 고정 50km — 사용자 설정은 차후)
- `findMonthlyStats` 쿼리에 `SUM(durationSeconds)` 추가 (기존 한 쿼리에 합산, 추가 쿼리 없음)
- 단위 테스트: 승격(완성/미완성), 통계(페이스 계산/기록없음)