### PR TITLE
[Feat] 진행 중 세션 응답에 누적 거리 추가

### DIFF
--- a/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunSessionActiveRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunSessionActiveRes.java
@@ -41,7 +41,7 @@ public class RunSessionActiveRes {
                 session.getStatus(),
                 session.getStartTime(),
                 session.getArtRunSessionId(),
-                session.getTotalDistance() != null ? session.getTotalDistance().doubleValue() : null
+                session.getTotalDistance().doubleValue()
         );
     }
 }

--- a/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunSessionActiveRes.java
+++ b/src/main/java/com/_s3k/runsync/domain/run/dto/response/RunSessionActiveRes.java
@@ -23,12 +23,16 @@ public class RunSessionActiveRes {
     @Schema(description = "연결된 협동 러닝 세션 ID (일반 러닝이면 null)", example = "100")
     private final Long artRunSessionId;
 
+    @Schema(description = "누적 이동 거리 (km). 새로고침/재접속 시 이어뛰기 거리 복원용", example = "1.25")
+    private final Double distance;
+
     private RunSessionActiveRes(Long sessionId, RunningSessionStatus status,
-                               LocalDateTime startTime, Long artRunSessionId) {
+                               LocalDateTime startTime, Long artRunSessionId, Double distance) {
         this.sessionId = sessionId;
         this.status = status;
         this.startTime = startTime;
         this.artRunSessionId = artRunSessionId;
+        this.distance = distance;
     }
 
     public static RunSessionActiveRes of(RunningSession session) {
@@ -36,7 +40,8 @@ public class RunSessionActiveRes {
                 session.getId(),
                 session.getStatus(),
                 session.getStartTime(),
-                session.getArtRunSessionId()
+                session.getArtRunSessionId(),
+                session.getTotalDistance() != null ? session.getTotalDistance().doubleValue() : null
         );
     }
 }

--- a/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
+++ b/src/test/java/com/_s3k/runsync/domain/run/service/RunSessionServiceTest.java
@@ -188,6 +188,7 @@ class RunSessionServiceTest {
         assertThat(result.get().getSessionId()).isEqualTo(5L);
         assertThat(result.get().getArtRunSessionId()).isEqualTo(100L);
         assertThat(result.get().getStatus()).isEqualTo(RunningSessionStatus.ACTIVE);
+        assertThat(result.get().getDistance()).isEqualTo(0.0);
     }
 
     @Test


### PR DESCRIPTION
## 📝작업 내용

러닝 도중 새로고침/재접속 시 "이어서 뛰기"를 하면, 프론트의 `resume` 누적 거리를 복원하려고 하는데 `GET /api/run-sessions/active` 응답에 거리 필드가 없어 **거리가 0부터 다시 카운트**되는 문제가 있었습니다. (시간은 startTime 기준으로 복원되지만 거리는 유실 → 최종 거리 과소 집계)

### 변경 사항
- `RunSessionActiveRes`에 `distance`(누적 이동 거리, km) 필드 추가
- `RunningSession.totalDistance`를 그대로 내려줌 (null이면 null)
- 관련 테스트에 distance 검증 assertion 추가
